### PR TITLE
add node builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,7 @@ checksum = "a725039ef382d1b6b4e2ebcb15b1efff6cde9af48c47a1bdce6fb67b9456c34b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
  "num_enum",
- "proptest",
  "serde",
  "strum",
 ]
@@ -121,11 +119,9 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
- "arbitrary",
  "auto_impl",
  "c-kzg",
  "derive_more",
- "rand",
  "serde",
  "serde_with",
 ]
@@ -170,9 +166,7 @@ checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
  "crc",
- "rand",
  "serde",
  "thiserror 2.0.11",
 ]
@@ -185,8 +179,6 @@ checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
- "rand",
  "serde",
 ]
 
@@ -198,10 +190,8 @@ checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
  "derive_more",
  "k256",
- "rand",
  "serde",
  "serde_with",
 ]
@@ -217,7 +207,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "arbitrary",
  "c-kzg",
  "derive_more",
  "ethereum_ssz",
@@ -311,11 +300,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_arbitrary",
  "derive_more",
  "foldhash",
  "getrandom",
@@ -326,7 +313,6 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "proptest-derive",
  "rand",
  "ruint",
  "rustc-hash 2.1.0",
@@ -549,7 +535,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "arbitrary",
  "itertools 0.13.0",
  "jsonrpsee-types",
  "serde",
@@ -604,7 +589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
 dependencies = [
  "alloy-primitives",
- "arbitrary",
  "serde",
  "serde_json",
 ]
@@ -770,13 +754,9 @@ checksum = "6917c79e837aa7b77b7a6dae9f89cbe15313ac161c4d3cfaf8909ef21f3d22d8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
  "arrayvec",
- "derive_arbitrary",
  "derive_more",
  "nybbles",
- "proptest",
- "proptest-derive",
  "serde",
  "smallvec",
  "tracing",
@@ -865,15 +845,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
 ]
 
 [[package]]
@@ -1322,7 +1293,6 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
- "arbitrary",
  "serde",
 ]
 
@@ -1337,6 +1307,19 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1873,6 +1856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1875,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2200,17 +2199,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -2932,12 +2920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash-db"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,6 +3209,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3509,7 +3492,6 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
- "arbitrary",
  "equivalent",
  "hashbrown 0.15.2",
  "serde",
@@ -4404,7 +4386,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4583,7 +4565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "const-hex",
  "proptest",
  "serde",
@@ -4620,31 +4601,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "arbitrary",
  "derive_more",
  "maili-common",
  "serde",
  "serde_with",
  "thiserror 2.0.11",
-]
-
-[[package]]
-name = "op-alloy-rpc-types"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b700b5d4efbe6433abb13e52f18a5f9ffe8d8fe9aeef99912bc90ffe0d7ebc"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "arbitrary",
- "derive_more",
- "op-alloy-consensus",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4725,7 +4686,6 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
- "arbitrary",
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
@@ -4904,15 +4864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "plain_hasher"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,27 +5029,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "proptest-arbitrary-interop"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
-dependencies = [
- "arbitrary",
- "proptest",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -5407,6 +5337,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -5440,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5510,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5537,18 +5468,15 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
  "derive_more",
  "metrics",
  "parking_lot",
  "pin-project",
- "rand",
  "reth-chainspec",
  "reth-errors",
  "reth-execution-types",
@@ -5566,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5585,7 +5513,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -5599,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "ahash",
  "alloy-consensus",
@@ -5661,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5671,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5689,26 +5617,24 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
- "arbitrary",
  "bytes",
  "modular-bitfield",
  "op-alloy-consensus",
  "reth-codecs-derive",
  "serde",
- "visibility",
 ]
 
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -5719,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -5733,7 +5659,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5747,7 +5673,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5760,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5784,7 +5710,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5793,7 +5719,6 @@ dependencies = [
  "eyre",
  "metrics",
  "page_size",
- "parking_lot",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
@@ -5810,28 +5735,24 @@ dependencies = [
  "serde",
  "strum",
  "sysinfo",
- "tempfile",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "reth-db-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
- "arbitrary",
  "bytes",
  "derive_more",
  "metrics",
  "modular-bitfield",
  "parity-scale-codec",
- "proptest",
  "reth-codecs",
  "reth-db-models",
- "reth-optimism-primitives",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
@@ -5845,7 +5766,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5874,14 +5795,12 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "arbitrary",
  "bytes",
  "modular-bitfield",
- "proptest",
  "reth-codecs",
  "reth-primitives-traits",
  "serde",
@@ -5890,7 +5809,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5916,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5940,7 +5859,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -5964,7 +5883,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5978,8 +5897,6 @@ dependencies = [
  "rayon",
  "reth-config",
  "reth-consensus",
- "reth-db",
- "reth-db-api",
  "reth-metrics",
  "reth-network-p2p",
  "reth-network-peers",
@@ -5987,8 +5904,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
- "reth-testing-utils",
- "tempfile",
  "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
@@ -5999,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6030,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6060,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6081,7 +5996,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "futures",
  "pin-project",
@@ -6104,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6117,7 +6032,6 @@ dependencies = [
  "moka",
  "rayon",
  "reth-chain-state",
- "reth-chainspec",
  "reth-consensus",
  "reth-db",
  "reth-engine-primitives",
@@ -6133,13 +6047,9 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
- "reth-prune-types",
  "reth-revm",
- "reth-stages",
  "reth-stages-api",
- "reth-static-file",
  "reth-tasks",
- "reth-tracing",
  "reth-trie",
  "reth-trie-db",
  "reth-trie-parallel",
@@ -6154,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6188,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6200,7 +6110,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6228,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6240,7 +6150,7 @@ dependencies = [
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-forks",
- "reth-primitives",
+ "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
  "thiserror 2.0.11",
@@ -6249,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "eyre",
  "reth-chainspec",
@@ -6259,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6275,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6295,12 +6205,11 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
  "alloy-primitives",
- "arbitrary",
  "auto_impl",
  "dyn-clone",
  "once_cell",
@@ -6311,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6336,9 +6245,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ethereum-primitives"
+version = "1.1.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "derive_more",
+ "modular-bitfield",
+ "once_cell",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "reth-zstd-compressors",
+ "revm-primitives",
+ "secp256k1 0.29.1",
+ "serde",
+]
+
+[[package]]
 name = "reth-etl"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6348,7 +6280,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6356,7 +6288,6 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "metrics",
- "parking_lot",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -6375,12 +6306,13 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-sol-types",
+ "derive_more",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-consensus",
@@ -6395,7 +6327,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6411,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6429,7 +6361,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6465,7 +6397,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6480,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "serde",
  "serde_json",
@@ -6490,7 +6422,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6517,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6538,7 +6470,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "bitflags 2.8.0",
  "byteorder",
@@ -6555,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "bindgen",
  "cc",
@@ -6564,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "futures",
  "metrics",
@@ -6576,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6584,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6598,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6642,7 +6574,6 @@ dependencies = [
  "secp256k1 0.29.1",
  "serde",
  "smallvec",
- "tempfile",
  "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
@@ -6653,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -6676,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6684,7 +6615,6 @@ dependencies = [
  "auto_impl",
  "derive_more",
  "futures",
- "parking_lot",
  "reth-consensus",
  "reth-eth-wire-types",
  "reth-network-peers",
@@ -6699,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6714,7 +6644,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -6728,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6745,7 +6675,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -6766,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6784,7 +6714,6 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
- "reth-db",
  "reth-db-api",
  "reth-db-common",
  "reth-downloaders",
@@ -6828,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6877,7 +6806,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "eyre",
  "reth-basic-payload-builder",
@@ -6905,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6929,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "eyre",
  "http",
@@ -6951,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -6961,37 +6890,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-optimism-primitives"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "bytes",
- "derive_more",
- "modular-bitfield",
- "once_cell",
- "op-alloy-consensus",
- "proptest",
- "rand",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-zstd-compressors",
- "revm-primitives",
- "secp256k1 0.29.1",
- "serde",
-]
-
-[[package]]
 name = "reth-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
  "alloy-rpc-types",
  "async-trait",
  "futures-util",
@@ -7001,7 +6904,6 @@ dependencies = [
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "tokio",
  "tokio-stream",
@@ -7011,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-rpc-types-engine",
  "async-trait",
@@ -7025,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7043,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7053,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-rpc-types",
  "reth-chainspec",
@@ -7064,40 +6966,25 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-network",
  "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
- "alloy-serde",
  "alloy-trie",
- "arbitrary",
- "bytes",
  "c-kzg",
  "derive_more",
- "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "rand",
- "reth-codecs",
  "reth-ethereum-forks",
+ "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-static-file-types",
- "reth-zstd-compressors",
- "revm-primitives",
- "secp256k1 0.29.1",
  "serde",
- "serde_with",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7105,7 +6992,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "arbitrary",
  "auto_impl",
  "byteorder",
  "bytes",
@@ -7114,8 +7000,6 @@ dependencies = [
  "modular-bitfield",
  "once_cell",
  "op-alloy-consensus",
- "proptest",
- "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
  "revm-primitives",
@@ -7128,7 +7012,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7147,7 +7031,6 @@ dependencies = [
  "reth-db",
  "reth-db-api",
  "reth-errors",
- "reth-ethereum-engine-primitives",
  "reth-evm",
  "reth-execution-types",
  "reth-fs-util",
@@ -7155,7 +7038,6 @@ dependencies = [
  "reth-network-p2p",
  "reth-nippy-jar",
  "reth-node-types",
- "reth-optimism-primitives",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
@@ -7173,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7202,10 +7084,9 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
- "arbitrary",
  "derive_more",
  "modular-bitfield",
  "reth-codecs",
@@ -7216,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7233,7 +7114,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7302,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7327,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -7363,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7393,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7437,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7454,6 +7335,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
+ "reth-evm",
  "reth-execution-types",
  "reth-metrics",
  "reth-primitives",
@@ -7479,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -7493,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7509,7 +7391,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7525,17 +7407,18 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "bincode",
+ "blake3",
  "futures-util",
  "itertools 0.13.0",
  "num-traits",
  "rayon",
- "reth-chainspec",
+ "reqwest",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
@@ -7545,6 +7428,7 @@ dependencies = [
  "reth-evm",
  "reth-execution-types",
  "reth-exex",
+ "reth-fs-util",
  "reth-network-p2p",
  "reth-primitives",
  "reth-primitives-traits",
@@ -7554,10 +7438,9 @@ dependencies = [
  "reth-revm",
  "reth-stages-api",
  "reth-storage-errors",
- "reth-testing-utils",
  "reth-trie",
  "reth-trie-db",
- "tempfile",
+ "serde",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
@@ -7566,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7593,10 +7476,9 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
- "arbitrary",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
@@ -7607,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -7628,7 +7510,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7640,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7665,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7680,7 +7562,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7696,24 +7578,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-testing-utils"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "rand",
- "reth-primitives",
- "reth-primitives-traits",
- "secp256k1 0.29.1",
-]
-
-[[package]]
 name = "reth-tokio-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7723,7 +7590,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "clap",
  "eyre",
@@ -7738,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7750,7 +7617,6 @@ dependencies = [
  "futures-util",
  "metrics",
  "parking_lot",
- "paste",
  "rand",
  "reth-chain-state",
  "reth-chainspec",
@@ -7778,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7798,13 +7664,12 @@ dependencies = [
  "reth-trie-sparse",
  "revm",
  "tracing",
- "triehash",
 ]
 
 [[package]]
 name = "reth-trie-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7812,13 +7677,10 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-trie",
- "arbitrary",
  "bytes",
  "derive_more",
- "hash-db",
  "itertools 0.13.0",
  "nybbles",
- "plain_hasher",
  "reth-codecs",
  "reth-primitives-traits",
  "serde",
@@ -7828,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7843,13 +7705,12 @@ dependencies = [
  "reth-trie",
  "revm",
  "tracing",
- "triehash",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7872,7 +7733,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7887,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=11bd9dded36c694afbc8b1b550e690976f8d25f0#11bd9dded36c694afbc8b1b550e690976f8d25f0"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=6c3b1b8bcd7f86e115ab4703719056dc8998a00e#6c3b1b8bcd7f86e115ab4703719056dc8998a00e"
 dependencies = [
  "zstd",
 ]
@@ -7950,7 +7811,7 @@ dependencies = [
  "once_cell",
  "revm-primitives",
  "ripemd",
- "secp256k1 0.29.1",
+ "secp256k1 0.28.2",
  "sha2 0.10.8",
  "substrate-bn",
 ]
@@ -8088,7 +7949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
@@ -8195,7 +8055,19 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -8222,16 +8094,16 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "webpki-roots",
  "winapi",
@@ -8388,10 +8260,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
  "num-bigint",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "libc",
  "security-framework-sys",
 ]
 
@@ -8717,7 +8602,6 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
- "arbitrary",
  "serde",
 ]
 
@@ -8760,8 +8644,8 @@ dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
- "reth",
  "reth-chainspec",
+ "reth-revm",
  "serde_json",
 ]
 
@@ -8783,6 +8667,7 @@ version = "0.0.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-sol-types",
  "bitcoin",
@@ -8791,12 +8676,14 @@ dependencies = [
  "hex",
  "parking_lot",
  "reqwest",
- "reth",
  "reth-chainspec",
  "reth-evm",
  "reth-node-api",
  "reth-node-ethereum",
  "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
  "reth-tracing",
  "serde",
  "serde_json",
@@ -8809,20 +8696,53 @@ version = "0.0.2"
 dependencies = [
  "bitcoin",
  "clap",
+ "eyre",
+ "reth-basic-payload-builder",
+ "reth-chainspec",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-payload-builder",
+ "reth-evm",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-ethereum",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-transaction-pool",
+ "reth-trie-db",
+ "sova-cli",
+ "sova-evm",
+ "sova-payload",
 ]
 
 [[package]]
 name = "sova-payload"
 version = "0.0.2"
 dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
  "eyre",
- "reth",
+ "reth-basic-payload-builder",
+ "reth-chain-state",
  "reth-chainspec",
+ "reth-errors",
+ "reth-ethereum-payload-builder",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-execution-types",
  "reth-node-ethereum",
+ "reth-payload-builder",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
  "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-tracing",
+ "reth-transaction-pool",
  "sova-cli",
  "sova-evm",
- "sova-node",
 ]
 
 [[package]]
@@ -8831,13 +8751,10 @@ version = "0.0.2"
 dependencies = [
  "clap",
  "reth",
- "reth-cli",
  "reth-cli-util",
- "reth-node-ethereum",
+ "reth-tracing",
  "sova-cli",
- "sova-evm",
  "sova-node",
- "sova-payload",
 ]
 
 [[package]]
@@ -8995,7 +8912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -9525,16 +9442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triehash"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
-dependencies = [
- "hash-db",
- "rlp",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9747,17 +9654,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "visibility"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,36 @@ sova-node = { path = "crates/node" }
 sova-payload = { path = "crates/payload" }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0", features = ["test-utils"] }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "11bd9dded36c694afbc8b1b550e690976f8d25f0" }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }
 
 # alloy
 alloy-consensus = { version = "0.9.2", default-features = false }
 alloy-dyn-abi = "0.8.15"
+alloy-eips = { version = "0.9.2", default-features = false }
 alloy-genesis = { version = "0.9.2", default-features = false }
 alloy-primitives = { version = "0.8.15", default-features = false }
 alloy-sol-types = "0.8.15"

--- a/bin/sova/Cargo.toml
+++ b/bin/sova/Cargo.toml
@@ -8,14 +8,11 @@ repository.workspace = true
 
 [dependencies]
 sova-cli.workspace = true
-sova-evm.workspace = true
 sova-node.workspace = true
-sova-payload.workspace = true
 
 reth.workspace = true
 reth-cli-util.workspace = true
-reth-cli.workspace = true
-reth-node-ethereum.workspace = true
+reth-tracing.workspace = true
 
 clap.workspace = true
 

--- a/bin/sova/src/main.rs
+++ b/bin/sova/src/main.rs
@@ -1,12 +1,10 @@
 use clap::Parser;
 
-use reth::{cli::Cli, providers::providers::BlockchainProvider};
-use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth::cli::Cli;
+use reth_tracing::tracing::info;
 
-use sova_cli::{SovaChainSpecParser, SovaConfig};
-use sova_evm::MyExecutorBuilder;
-use sova_node::SovaArgs;
-use sova_payload::MyPayloadBuilder;
+use sova_cli::SovaChainSpecParser;
+use sova_node::{SovaArgs, SovaNode};
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
@@ -23,28 +21,8 @@ fn main() {
         // Using SovaChainSpecParser for inheriting all ethereum forkchoices
         // Sova args are used to provide flags for auxiliary services
         Cli::<SovaChainSpecParser, SovaArgs>::parse().run(|builder, sova_args| async move {
-                let app_config: SovaConfig = SovaConfig::new(
-                    &sova_args.btc_network,
-                    &sova_args.network_url,
-                    &sova_args.btc_rpc_username,
-                    &sova_args.btc_rpc_password,
-                    &sova_args.network_signing_url,
-                    &sova_args.network_utxo_url,
-                    &sova_args.btc_tx_queue_url,
-                );
-
-                let handle = builder
-                    .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
-                    .with_components(
-                        EthereumNode::components()
-                            .executor(MyExecutorBuilder::new(&app_config))
-                            .payload(MyPayloadBuilder::new(&app_config)),
-                    )
-                    .with_add_ons(EthereumAddOns::default())
-                    .launch()
-                    .await
-                    .unwrap();
-
+                info!(target: "reth::cli", "Launching node");
+                let handle = builder.launch_node(SovaNode::new(sova_args)).await?;
                 handle.node_exit_future.await
             })
     {

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 keywords.workspace = true
 
 [dependencies]
-reth.workspace = true
 reth-chainspec.workspace = true
+reth-revm.workspace = true
 
 alloy-consensus.workspace = true
 alloy-genesis.workspace = true

--- a/crates/chainspec/src/dev.rs
+++ b/crates/chainspec/src/dev.rs
@@ -6,8 +6,8 @@ use std::{
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{address, b256, Address, Bytes, U256};
 
-use reth::revm::primitives::hex;
 use reth_chainspec::{Chain, ChainSpec, ChainSpecBuilder, DepositContract};
+use reth_revm::primitives::hex;
 
 use crate::constants::{deposit_contract_storage, DEPOSIT_CONTRACT_ADDRESS, DEPOSIT_CONTRACT_CODE};
 

--- a/crates/chainspec/src/mainnet.rs
+++ b/crates/chainspec/src/mainnet.rs
@@ -5,6 +5,7 @@ use std::{
 
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{address, b256, Address, Bytes, U256};
+
 use reth_chainspec::{Chain, ChainSpec, ChainSpecBuilder, DepositContract};
 
 use crate::constants::{deposit_contract_storage, DEPOSIT_CONTRACT_ADDRESS, DEPOSIT_CONTRACT_CODE};

--- a/crates/chainspec/src/testnet.rs
+++ b/crates/chainspec/src/testnet.rs
@@ -5,6 +5,7 @@ use std::{
 
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{address, b256, Address, Bytes, U256};
+
 use reth_chainspec::{Chain, ChainSpec, ChainSpecBuilder, DepositContract};
 
 use crate::constants::{deposit_contract_storage, DEPOSIT_CONTRACT_ADDRESS, DEPOSIT_CONTRACT_CODE};

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -10,16 +10,19 @@ keywords.workspace = true
 [dependencies]
 sova-cli.workspace = true
 
-reth.workspace = true
 reth-chainspec.workspace = true
 reth-evm.workspace = true
 reth-node-api.workspace = true
 reth-node-ethereum.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
+reth-provider.workspace = true
 reth-tracing.workspace = true
+reth-revm.workspace = true
 
 alloy-consensus.workspace = true
 alloy-dyn-abi.workspace = true
+alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 

--- a/crates/evm/src/abi.rs
+++ b/crates/evm/src/abi.rs
@@ -2,7 +2,7 @@ use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_primitives::{Address, Bytes, FixedBytes, U256};
 use alloy_sol_types::{sol, SolValue};
 
-use reth::revm::precompile::{PrecompileError, PrecompileErrors};
+use reth_revm::precompile::{PrecompileError, PrecompileErrors};
 
 use bitcoin::hashes::Hash;
 use bitcoin::Network;

--- a/crates/evm/src/client/mod.rs
+++ b/crates/evm/src/client/mod.rs
@@ -1,3 +1,3 @@
 mod bitcoin;
 
-pub use bitcoin::*;
+pub use bitcoin::BitcoinClientWrapper;

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -1,44 +1,216 @@
-use reth::builder::{components::ExecutorBuilder, BuilderContext};
-use reth_chainspec::ChainSpec;
-use reth_node_api::{FullNodeTypes, NodeTypes};
-use reth_node_ethereum::{BasicBlockExecutorProvider, EthExecutionStrategyFactory};
-use reth_primitives::EthPrimitives;
+use std::{fmt::Display, sync::Arc};
 
-use sova_cli::SovaConfig;
+use alloy_consensus::{BlockHeader, Transaction};
+use alloy_eips::eip7685::Requests;
+
+use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_evm::{
+    execute::{
+        BlockExecutionError, BlockExecutionStrategy, BlockExecutionStrategyFactory,
+        BlockValidationError, ExecuteOutput,
+    },
+    system_calls::SystemCaller,
+    ConfigureEvm, Evm, TxEnvOverrides,
+};
+use reth_node_api::BlockBody;
+use reth_primitives::{EthPrimitives, Receipt, RecoveredBlock};
+use reth_primitives_traits::transaction::signed::SignedTransaction;
+use reth_provider::ProviderError;
+use reth_revm::{db::State, primitives::ResultAndState, Database, DatabaseCommit};
 
 use crate::MyEvmConfig;
 
-#[derive(Clone)]
-pub struct MyExecutorBuilder {
-    config: SovaConfig,
+pub struct MyExecutionStrategy<DB, EvmConfig>
+where
+    EvmConfig: Clone,
+{
+    /// The chainspec
+    chain_spec: Arc<ChainSpec>,
+    /// How to create an EVM
+    evm_config: EvmConfig,
+    /// Optional overrides for the transactions environment.
+    tx_env_overrides: Option<Box<dyn TxEnvOverrides>>,
+    /// Current state for block execution
+    state: State<DB>,
+    /// Utility to call system smart contracts.
+    system_caller: SystemCaller<EvmConfig, ChainSpec>,
 }
 
-impl MyExecutorBuilder {
-    pub fn new(config: &SovaConfig) -> Self {
+impl<DB, EvmConfig> MyExecutionStrategy<DB, EvmConfig>
+where
+    EvmConfig: Clone,
+{
+    pub fn new(state: State<DB>, chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
+        let system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
         Self {
-            config: config.clone(),
+            state,
+            chain_spec,
+            evm_config,
+            tx_env_overrides: None,
+            system_caller,
         }
     }
 }
 
-impl<Node> ExecutorBuilder<Node> for MyExecutorBuilder
+impl<DB, EvmConfig> BlockExecutionStrategy for MyExecutionStrategy<DB, EvmConfig>
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = EthPrimitives>>,
+    DB: Database<Error: Into<ProviderError> + Display>,
+    EvmConfig: ConfigureEvm<
+        Header = alloy_consensus::Header,
+        Transaction = reth_primitives::TransactionSigned,
+    >,
 {
-    type EVM = MyEvmConfig;
-    type Executor = BasicBlockExecutorProvider<EthExecutionStrategyFactory<Self::EVM>>;
+    type DB = DB;
+    type Error = BlockExecutionError;
+    type Primitives = EthPrimitives;
 
-    async fn build_evm(
-        self,
-        ctx: &BuilderContext<Node>,
-    ) -> eyre::Result<(Self::EVM, Self::Executor)> {
-        let evm_config = MyEvmConfig::new(&self.config, ctx.chain_spec());
-        Ok((
-            evm_config.clone(),
-            BasicBlockExecutorProvider::new(EthExecutionStrategyFactory::new(
-                ctx.chain_spec(),
-                evm_config,
-            )),
-        ))
+    fn init(&mut self, tx_env_overrides: Box<dyn TxEnvOverrides>) {
+        self.tx_env_overrides = Some(tx_env_overrides);
+    }
+
+    fn apply_pre_execution_changes(
+        &mut self,
+        block: &RecoveredBlock<reth_primitives::Block>,
+    ) -> Result<(), Self::Error> {
+        // Set state clear flag if the block is after the Spurious Dragon hardfork
+        let state_clear_flag = self
+            .chain_spec
+            .is_spurious_dragon_active_at_block(block.number);
+        self.state.set_state_clear_flag(state_clear_flag);
+
+        Ok(())
+    }
+
+    fn execute_transactions(
+        &mut self,
+        block: &RecoveredBlock<reth_primitives::Block>,
+    ) -> Result<ExecuteOutput<Receipt>, Self::Error> {
+        let cfg_and_block_env = self.evm_config.cfg_and_block_env(block.header());
+        let mut evm = self
+            .evm_config
+            .evm_with_env(&mut self.state, cfg_and_block_env);
+
+        let mut cumulative_gas_used = 0;
+        let mut receipts = Vec::with_capacity(block.body().transaction_count());
+
+        for (sender, transaction) in block.transactions_with_sender() {
+            // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
+            // must be no greater than the block’s gasLimit.
+            let block_available_gas = block.gas_limit() - cumulative_gas_used;
+            if transaction.gas_limit() > block_available_gas {
+                return Err(
+                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                        transaction_gas_limit: transaction.gas_limit(),
+                        block_available_gas,
+                    }
+                    .into(),
+                );
+            }
+
+            let mut tx_env = self.evm_config.tx_env(transaction, *sender);
+
+            if let Some(tx_env_overrides) = &mut self.tx_env_overrides {
+                tx_env_overrides.apply(&mut tx_env);
+            }
+
+            // Execute transaction.
+            let result_and_state = evm.transact(tx_env).map_err(move |err| {
+                let new_err = err.map_db_err(|e| e.into());
+                // Ensure hash is calculated for error log, if not already done
+                BlockValidationError::EVM {
+                    hash: transaction.recalculate_hash(),
+                    error: Box::new(new_err),
+                }
+            })?;
+            self.system_caller.on_state(&result_and_state.state);
+            let ResultAndState { result, state } = result_and_state;
+            evm.db_mut().commit(state);
+
+            // append gas used
+            cumulative_gas_used += result.gas_used();
+
+            // Push transaction changeset and calculate header bloom filter for receipt.
+            receipts.push(
+                #[allow(clippy::needless_update)] // side-effect of optimism fields
+                Receipt {
+                    tx_type: transaction.tx_type(),
+                    // Success flag was added in `EIP-658: Embedding transaction status code in
+                    // receipts`.
+                    success: result.is_success(),
+                    cumulative_gas_used,
+                    // convert to reth log
+                    logs: result.into_logs(),
+                    ..Default::default()
+                },
+            );
+        }
+
+        Ok(ExecuteOutput {
+            receipts,
+            gas_used: cumulative_gas_used,
+        })
+    }
+
+    fn apply_post_execution_changes(
+        &mut self,
+        _block: &RecoveredBlock<reth_primitives::Block>,
+        _receipts: &[Receipt],
+    ) -> Result<Requests, Self::Error> {
+        Ok(Requests::default())
+    }
+
+    fn state_ref(&self) -> &State<DB> {
+        &self.state
+    }
+
+    fn state_mut(&mut self) -> &mut State<DB> {
+        &mut self.state
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MyExecutionStrategyFactory<EvmConfig = MyEvmConfig> {
+    /// Describes the properties of the chain
+    pub chain_spec: Arc<ChainSpec>,
+    /// Config for EVM that includes Bitcoin precompile setup
+    pub evm_config: EvmConfig,
+}
+
+impl<EvmConfig> MyExecutionStrategyFactory<EvmConfig> {
+    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
+        Self {
+            chain_spec,
+            evm_config,
+        }
+    }
+}
+
+impl<EvmConfig> BlockExecutionStrategyFactory for MyExecutionStrategyFactory<EvmConfig>
+where
+    EvmConfig: Clone
+        + Unpin
+        + Sync
+        + Send
+        + 'static
+        + ConfigureEvm<
+            Header = alloy_consensus::Header,
+            Transaction = reth_primitives::TransactionSigned,
+        >,
+{
+    type Primitives = EthPrimitives;
+    type Strategy<DB: Database<Error: Into<ProviderError> + Display>> =
+        MyExecutionStrategy<DB, EvmConfig>;
+
+    fn create_strategy<DB>(&self, db: DB) -> Self::Strategy<DB>
+    where
+        DB: Database<Error: Into<ProviderError> + Display>,
+    {
+        let state = State::builder()
+            .with_database(db)
+            .with_bundle_update()
+            .without_state_clear()
+            .build();
+
+        MyExecutionStrategy::new(state, self.chain_spec.clone(), self.evm_config.clone())
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -3,30 +3,31 @@ mod client;
 mod execute;
 mod precompiles;
 
-use crate::precompiles::BitcoinRpcPrecompile;
 pub use abi::*;
 pub use client::*;
 pub use execute::*;
+
+use crate::precompiles::BitcoinRpcPrecompile;
 
 use std::{convert::Infallible, sync::Arc};
 
 use parking_lot::RwLock;
 
 use alloy_consensus::Header;
-use alloy_primitives::{address, Address, Bytes};
+use alloy_primitives::{address, Address};
 
-use reth::revm::{
-    handler::register::EvmHandler,
-    inspector_handle_register,
-    precompile::PrecompileSpecId,
-    primitives::{CfgEnvWithHandlerCfg, Env, Precompile, TxEnv},
-    ContextPrecompile, ContextPrecompiles, Database, Evm, EvmBuilder, GetInspector,
-};
 use reth_chainspec::ChainSpec;
 use reth_evm::{env::EvmEnv, ConfigureEvm};
 use reth_node_api::{ConfigureEvmEnv, NextBlockEnvAttributes};
-use reth_node_ethereum::EthEvmConfig;
+use reth_node_ethereum::{evm::EthEvm, EthEvmConfig};
 use reth_primitives::TransactionSigned;
+use reth_revm::{
+    handler::register::EvmHandler,
+    inspector_handle_register,
+    precompile::PrecompileSpecId,
+    primitives::{CfgEnvWithHandlerCfg, Precompile, TxEnv},
+    ContextPrecompile, ContextPrecompiles, Database, EvmBuilder, GetInspector,
+};
 
 use sova_cli::SovaConfig;
 
@@ -85,17 +86,6 @@ impl ConfigureEvmEnv for MyEvmConfig {
         self.inner.fill_tx_env(tx_env, transaction, sender);
     }
 
-    fn fill_tx_env_system_contract_call(
-        &self,
-        env: &mut Env,
-        caller: Address,
-        contract: Address,
-        data: Bytes,
-    ) {
-        self.inner
-            .fill_tx_env_system_contract_call(env, caller, contract, data);
-    }
-
     fn fill_cfg_env(&self, cfg_env: &mut CfgEnvWithHandlerCfg, header: &Self::Header) {
         self.inner.fill_cfg_env(cfg_env, header);
     }
@@ -110,26 +100,27 @@ impl ConfigureEvmEnv for MyEvmConfig {
 }
 
 impl ConfigureEvm for MyEvmConfig {
-    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB> {
+    type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
+
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         EvmBuilder::default()
             .with_db(db)
             .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
             // add BTC precompiles
             .append_handler_register_box(Box::new(move |handler| {
                 MyEvmConfig::set_precompiles(handler, self.bitcoin_rpc_precompile.clone())
             }))
             .build()
+            .into()
     }
 
     fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
         evm_env: EvmEnv,
-        tx: TxEnv,
         inspector: I,
-    ) -> Evm<'_, I, DB>
+    ) -> Self::Evm<'_, DB, I>
     where
         DB: Database,
         I: GetInspector<DB>,
@@ -139,12 +130,12 @@ impl ConfigureEvm for MyEvmConfig {
             .with_external_context(inspector)
             .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
             // add additional precompiles
             .append_handler_register_box(Box::new(move |handler| {
                 MyEvmConfig::set_precompiles(handler, self.bitcoin_rpc_precompile.clone())
             }))
             .append_handler_register(inspector_handle_register)
             .build()
+            .into()
     }
 }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use alloy_primitives::Bytes;
 
-use reth::revm::primitives::{
+use reth_revm::primitives::{
     Env, PrecompileError, PrecompileErrors, PrecompileOutput, PrecompileResult, StatefulPrecompile,
 };
 use reth_tracing::tracing::{error, info};

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -8,5 +8,25 @@ repository.workspace = true
 keywords.workspace = true
 
 [dependencies]
+sova-cli.workspace = true
+sova-evm.workspace = true
+sova-payload.workspace = true
+
+reth-basic-payload-builder.workspace = true
+reth-chainspec.workspace = true
+reth-ethereum-engine-primitives.workspace = true
+reth-ethereum-payload-builder.workspace = true
+reth-evm.workspace = true
+reth-node-api.workspace = true
+reth-node-builder.workspace = true
+reth-node-ethereum.workspace = true
+reth-payload-builder.workspace = true
+reth-primitives.workspace = true
+reth-provider.workspace = true
+reth-transaction-pool.workspace = true
+reth-trie-db.workspace = true
+
 bitcoin.workspace = true
+
 clap.workspace = true
+eyre.workspace = true

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -1,3 +1,5 @@
 mod args;
+mod node;
 
 pub use args::SovaArgs;
+pub use node::SovaNode;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,0 +1,247 @@
+use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
+use reth_chainspec::ChainSpec;
+use reth_ethereum_engine_primitives::{
+    EthBuiltPayload, EthEngineTypes, EthPayloadAttributes, EthPayloadBuilderAttributes,
+};
+use reth_ethereum_payload_builder::EthereumBuilderConfig;
+use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvmFor};
+use reth_node_api::TxTy;
+use reth_node_builder::{
+    components::{ComponentsBuilder, ExecutorBuilder, PayloadServiceBuilder},
+    node::{FullNodeTypes, NodeTypes, NodeTypesWithEngine},
+    BuilderContext, Node, NodeAdapter, NodeComponentsBuilder, PayloadBuilderConfig, PayloadTypes,
+};
+use reth_node_ethereum::{
+    node::{EthereumAddOns, EthereumConsensusBuilder, EthereumNetworkBuilder, EthereumPoolBuilder},
+    payload::EthereumPayloadBuilder,
+};
+use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
+use reth_primitives::EthPrimitives;
+use reth_provider::{CanonStateSubscriptions, EthStorage};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use reth_trie_db::MerklePatriciaTrie;
+
+use sova_cli::SovaConfig;
+use sova_evm::{MyEvmConfig, MyExecutionStrategyFactory};
+
+use crate::SovaArgs;
+
+/// Type configuration for a regular Sova node.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct SovaNode {
+    /// Additional Sova args
+    pub args: SovaArgs,
+}
+
+impl SovaNode {
+    /// Creates a new instance of the Sova node type.
+    pub fn new(args: SovaArgs) -> Self {
+        Self { args }
+    }
+
+    /// Returns the components for the given [`SovaArgs`].
+    pub fn components<Node>(
+        &self,
+    ) -> ComponentsBuilder<
+        Node,
+        EthereumPoolBuilder,
+        MyPayloadBuilder,
+        EthereumNetworkBuilder,
+        MyExecutorBuilder,
+        EthereumConsensusBuilder,
+    >
+    where
+        Node: FullNodeTypes<
+            Types: NodeTypesWithEngine<
+                Engine = EthEngineTypes,
+                ChainSpec = ChainSpec,
+                Primitives = EthPrimitives,
+            >,
+        >,
+    {
+        let btc_network: bitcoin::Network = self.args.btc_network.clone().into();
+
+        let sova_config: SovaConfig = SovaConfig::new(
+            &btc_network,
+            &self.args.network_url,
+            &self.args.btc_rpc_username,
+            &self.args.btc_rpc_password,
+            &self.args.network_signing_url,
+            &self.args.network_utxo_url,
+            &self.args.btc_tx_queue_url,
+        );
+        ComponentsBuilder::default()
+            .node_types::<Node>()
+            .pool(EthereumPoolBuilder::default())
+            .payload(MyPayloadBuilder::new(&sova_config))
+            .network(EthereumNetworkBuilder::default())
+            .executor(MyExecutorBuilder::new(&sova_config))
+            .consensus(EthereumConsensusBuilder::default())
+    }
+}
+
+impl NodeTypes for SovaNode {
+    type Primitives = EthPrimitives;
+    type ChainSpec = ChainSpec;
+    type StateCommitment = MerklePatriciaTrie;
+    type Storage = EthStorage;
+}
+
+impl NodeTypesWithEngine for SovaNode {
+    type Engine = EthEngineTypes;
+}
+
+impl<N> Node<N> for SovaNode
+where
+    N: FullNodeTypes<
+        Types: NodeTypesWithEngine<
+            Engine = EthEngineTypes,
+            ChainSpec = ChainSpec,
+            Primitives = EthPrimitives,
+            Storage = EthStorage,
+        >,
+    >,
+{
+    type ComponentsBuilder = ComponentsBuilder<
+        N,
+        EthereumPoolBuilder,
+        MyPayloadBuilder,
+        EthereumNetworkBuilder,
+        MyExecutorBuilder,
+        EthereumConsensusBuilder,
+    >;
+
+    type AddOns = EthereumAddOns<
+        NodeAdapter<N, <Self::ComponentsBuilder as NodeComponentsBuilder<N>>::Components>,
+    >;
+
+    fn components_builder(&self) -> Self::ComponentsBuilder {
+        Self::components(self)
+    }
+
+    fn add_ons(&self) -> Self::AddOns {
+        EthereumAddOns::default()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct MyPayloadBuilder {
+    pub inner: EthereumPayloadBuilder,
+    pub config: SovaConfig,
+}
+
+impl MyPayloadBuilder {
+    pub fn new(config: &SovaConfig) -> Self {
+        Self {
+            inner: EthereumPayloadBuilder::default(),
+            config: config.clone(),
+        }
+    }
+
+    /// A helper method initializing [`PayloadBuilderService`] with the given EVM config.
+    pub fn spawn<Types, Node, Evm, Pool>(
+        self,
+        evm_config: Evm,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+    ) -> eyre::Result<PayloadBuilderHandle<Types::Engine>>
+    where
+        Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
+        Node: FullNodeTypes<Types = Types>,
+        Evm: ConfigureEvmFor<Types::Primitives>,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+            + Unpin
+            + 'static,
+        Types::Engine: PayloadTypes<
+            BuiltPayload = EthBuiltPayload,
+            PayloadAttributes = EthPayloadAttributes,
+            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+        >,
+    {
+        let conf = ctx.payload_builder_config();
+        let payload_builder = sova_payload::MyPayloadBuilder::new(
+            evm_config,
+            EthereumBuilderConfig::new(conf.extra_data_bytes()).with_gas_limit(conf.gas_limit()),
+        );
+
+        let payload_job_config = BasicPayloadJobGeneratorConfig::default()
+            .interval(conf.interval())
+            .deadline(conf.deadline())
+            .max_payload_tasks(conf.max_payload_tasks());
+
+        let payload_generator = BasicPayloadJobGenerator::with_builder(
+            ctx.provider().clone(),
+            pool,
+            ctx.task_executor().clone(),
+            payload_job_config,
+            payload_builder,
+        );
+        let (payload_service, payload_builder) =
+            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
+
+        ctx.task_executor()
+            .spawn_critical("payload builder service", Box::pin(payload_service));
+
+        Ok(payload_builder)
+    }
+}
+
+impl<Types, Node, Pool> PayloadServiceBuilder<Node, Pool> for MyPayloadBuilder
+where
+    Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
+    Node: FullNodeTypes<Types = Types>,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
+    Types::Engine: PayloadTypes<
+        BuiltPayload = EthBuiltPayload,
+        PayloadAttributes = EthPayloadAttributes,
+        PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+    >,
+{
+    async fn spawn_payload_service(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+    ) -> eyre::Result<PayloadBuilderHandle<Types::Engine>> {
+        let evm_config = MyEvmConfig::new(&self.config, ctx.chain_spec());
+        self.spawn(evm_config, ctx, pool)
+    }
+}
+
+#[derive(Clone)]
+pub struct MyExecutorBuilder {
+    config: SovaConfig,
+}
+
+impl MyExecutorBuilder {
+    pub fn new(config: &SovaConfig) -> Self {
+        Self {
+            config: config.clone(),
+        }
+    }
+}
+
+impl<Node> ExecutorBuilder<Node> for MyExecutorBuilder
+where
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = EthPrimitives>>,
+{
+    type EVM = MyEvmConfig;
+    type Executor = BasicBlockExecutorProvider<MyExecutionStrategyFactory>;
+
+    async fn build_evm(
+        self,
+        ctx: &BuilderContext<Node>,
+    ) -> eyre::Result<(Self::EVM, Self::Executor)> {
+        let evm_config = MyEvmConfig::new(&self.config, ctx.chain_spec());
+        Ok((
+            evm_config.clone(),
+            BasicBlockExecutorProvider::new(MyExecutionStrategyFactory {
+                chain_spec: ctx.chain_spec(),
+                evm_config,
+            }),
+        ))
+    }
+}

--- a/crates/payload/Cargo.toml
+++ b/crates/payload/Cargo.toml
@@ -9,12 +9,29 @@ keywords.workspace = true
 
 [dependencies]
 sova-cli.workspace = true
-sova-node.workspace = true
 sova-evm.workspace = true
 
-reth.workspace = true
+reth-basic-payload-builder.workspace = true
+reth-chain-state.workspace = true
 reth-chainspec.workspace = true
+reth-ethereum-payload-builder.workspace = true
+reth-errors.workspace = true
+reth-evm.workspace = true
+reth-evm-ethereum.workspace = true
+reth-execution-types.workspace = true
 reth-node-ethereum.workspace = true
+reth-payload-builder.workspace = true
+reth-payload-builder-primitives.workspace = true
+reth-payload-primitives.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
+reth-provider.workspace = true
+reth-revm.workspace = true
+reth-tracing.workspace = true
+reth-transaction-pool.workspace = true
+
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
 
 eyre.workspace = true

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -1,54 +1,537 @@
-use reth::{
-    api::{FullNodeTypes, NodeTypesWithEngine, PayloadTypes},
-    builder::{components::PayloadServiceBuilder, BuilderContext},
-    payload::{EthBuiltPayload, EthPayloadBuilderAttributes},
-    rpc::types::engine::PayloadAttributes,
-    transaction_pool::{PoolTransaction, TransactionPool},
+use std::sync::Arc;
+
+use alloy_consensus::{Header, Transaction, Typed2718, EMPTY_OMMER_ROOT_HASH};
+use alloy_eips::{
+    eip4844::MAX_DATA_GAS_PER_BLOCK, eip6110, eip7685::Requests, eip7840::BlobParams,
+    merge::BEACON_NONCE,
+};
+use alloy_primitives::U256;
+
+use reth_basic_payload_builder::{
+    commit_withdrawals, is_better_payload, BuildArguments, BuildOutcome, PayloadBuilder,
+    PayloadConfig,
+};
+use reth_chain_state::ExecutedBlock;
+use reth_chainspec::{ChainSpec, ChainSpecProvider};
+use reth_errors::RethError;
+use reth_ethereum_payload_builder::EthereumBuilderConfig;
+use reth_evm::{
+    env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, Evm, NextBlockEnvAttributes,
+};
+use reth_evm_ethereum::eip6110::parse_deposits_from_receipts;
+use reth_execution_types::ExecutionOutcome;
+use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
+use reth_payload_builder_primitives::PayloadBuilderError;
+use reth_payload_primitives::PayloadBuilderAttributes;
+use reth_primitives::{
+    proofs::calculate_transaction_root, Block, BlockBody, EthereumHardforks,
+    InvalidTransactionError, Receipt, RecoveredBlock, TransactionSigned,
+};
+use reth_primitives_traits::{Block as _, SignedTransaction};
+use reth_provider::StateProviderFactory;
+use reth_revm::{
+    database::StateProviderDatabase,
+    db::{states::bundle_state::BundleRetention, State},
+    primitives::{EVMError, InvalidTransaction, ResultAndState},
+    DatabaseCommit,
+};
+use reth_tracing::tracing::{debug, trace, warn};
+use reth_transaction_pool::{
+    error::InvalidPoolTransactionError, noop::NoopTransactionPool, BestTransactions,
+    BestTransactionsAttributes, PoolTransaction, TransactionPool, ValidPoolTransaction,
 };
 
-use reth_chainspec::ChainSpec;
-use reth_node_ethereum::node::EthereumPayloadBuilder;
-use reth_primitives::{EthPrimitives, TransactionSigned};
-
-use sova_cli::SovaConfig;
 use sova_evm::MyEvmConfig;
 
-/// Builds a regular ethereum block executor that uses the custom EVM.
-#[derive(Debug, Default, Clone)]
-#[non_exhaustive]
-pub struct MyPayloadBuilder {
-    pub inner: EthereumPayloadBuilder,
-    pub config: SovaConfig,
+type BestTransactionsIter<Pool> = Box<
+    dyn BestTransactions<Item = Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>,
+>;
+
+/// Sova payload builder
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MyPayloadBuilder<EvmConfig = MyEvmConfig> {
+    /// The type responsible for creating the evm.
+    evm_config: EvmConfig,
+    /// Payload builder configuration.
+    builder_config: EthereumBuilderConfig,
 }
 
-impl MyPayloadBuilder {
-    pub fn new(config: &SovaConfig) -> Self {
+impl<EvmConfig> MyPayloadBuilder<EvmConfig> {
+    pub const fn new(evm_config: EvmConfig, builder_config: EthereumBuilderConfig) -> Self {
         Self {
-            inner: EthereumPayloadBuilder::default(),
-            config: config.clone(),
+            evm_config,
+            builder_config,
         }
     }
 }
 
-impl<Types, Node, Pool> PayloadServiceBuilder<Node, Pool> for MyPayloadBuilder
+impl<EvmConfig> MyPayloadBuilder<EvmConfig>
 where
-    Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
-    Node: FullNodeTypes<Types = Types>,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
-        + Unpin
-        + 'static,
-    Types::Engine: PayloadTypes<
-        BuiltPayload = EthBuiltPayload,
-        PayloadAttributes = PayloadAttributes,
-        PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-    >,
+    EvmConfig: ConfigureEvm<Header = Header>,
 {
-    async fn spawn_payload_service(
-        self,
-        ctx: &BuilderContext<Node>,
-        pool: Pool,
-    ) -> eyre::Result<reth::payload::PayloadBuilderHandle<Types::Engine>> {
-        let evm_config = MyEvmConfig::new(&self.config, ctx.chain_spec());
-        self.inner.spawn(evm_config, ctx, pool)
+    /// Returns the configured [`EvmEnv`] for the targeted payload
+    /// (that has the `parent` as its parent).
+    fn cfg_and_block_env(
+        &self,
+        config: &PayloadConfig<EthPayloadBuilderAttributes>,
+        parent: &Header,
+    ) -> Result<EvmEnv, EvmConfig::Error> {
+        let next_attributes = NextBlockEnvAttributes {
+            timestamp: config.attributes.timestamp(),
+            suggested_fee_recipient: config.attributes.suggested_fee_recipient(),
+            prev_randao: config.attributes.prev_randao(),
+            gas_limit: self.builder_config.gas_limit(parent.gas_limit),
+        };
+        self.evm_config
+            .next_cfg_and_block_env(parent, next_attributes)
     }
+}
+
+// Default implementation of [PayloadBuilder] for unit type
+impl<EvmConfig, Pool, Client> PayloadBuilder<Pool, Client> for MyPayloadBuilder<EvmConfig>
+where
+    EvmConfig: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+{
+    type Attributes = EthPayloadBuilderAttributes;
+    type BuiltPayload = EthBuiltPayload;
+
+    fn try_build(
+        &self,
+        args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
+    ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError> {
+        let evm_env = self
+            .cfg_and_block_env(&args.config, &args.config.parent_header)
+            .map_err(PayloadBuilderError::other)?;
+
+        let pool = args.pool.clone();
+        default_ethereum_payload(
+            self.evm_config.clone(),
+            self.builder_config.clone(),
+            args,
+            evm_env,
+            |attributes| pool.best_transactions_with_attributes(attributes),
+        )
+    }
+
+    fn build_empty_payload(
+        &self,
+        client: &Client,
+        config: PayloadConfig<Self::Attributes>,
+    ) -> Result<EthBuiltPayload, PayloadBuilderError> {
+        let args = BuildArguments::new(
+            client,
+            // we use defaults here because for the empty payload we don't need to execute anything
+            NoopTransactionPool::default(),
+            Default::default(),
+            config,
+            Default::default(),
+            None,
+        );
+
+        let evm_env = self
+            .cfg_and_block_env(&args.config, &args.config.parent_header)
+            .map_err(PayloadBuilderError::other)?;
+
+        let pool = args.pool.clone();
+
+        default_ethereum_payload(
+            self.evm_config.clone(),
+            self.builder_config.clone(),
+            args,
+            evm_env,
+            |attributes| pool.best_transactions_with_attributes(attributes),
+        )?
+        .into_payload()
+        .ok_or_else(|| PayloadBuilderError::MissingPayload)
+    }
+}
+
+/// Constructs an Ethereum transaction payload using the best transactions from the pool.
+///
+/// Given build arguments including an Ethereum client, transaction pool,
+/// and configuration, this function creates a transaction payload. Returns
+/// a result indicating success with the payload or an error in case of failure.
+#[inline]
+pub fn default_ethereum_payload<EC, Pool, Client, F>(
+    evm_config: EC,
+    builder_config: EthereumBuilderConfig,
+    args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
+    evm_env: EvmEnv,
+    best_txs: F,
+) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
+where
+    EC: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
+{
+    let BuildArguments {
+        client,
+        pool,
+        mut cached_reads,
+        config,
+        cancel,
+        best_payload,
+    } = args;
+
+    let chain_spec = client.chain_spec();
+    let state_provider = client.state_by_block_hash(config.parent_header.hash())?;
+    let state = StateProviderDatabase::new(state_provider);
+    let mut db = State::builder()
+        .with_database(cached_reads.as_db_mut(state))
+        .with_bundle_update()
+        .build();
+    let PayloadConfig {
+        parent_header,
+        attributes,
+    } = config;
+
+    debug!(target: "payload_builder", id=%attributes.id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
+    let mut cumulative_gas_used = 0;
+    let mut sum_blob_gas_used = 0;
+    let block_gas_limit: u64 = evm_env.block_env.gas_limit.to::<u64>();
+    let base_fee = evm_env.block_env.basefee.to::<u64>();
+
+    let mut executed_txs = Vec::new();
+    let mut executed_senders = Vec::new();
+
+    let mut best_txs = best_txs(BestTransactionsAttributes::new(
+        base_fee,
+        evm_env
+            .block_env
+            .get_blob_gasprice()
+            .map(|gasprice| gasprice as u64),
+    ));
+    let mut total_fees = U256::ZERO;
+
+    let block_number = evm_env.block_env.number.to::<u64>();
+    let beneficiary = evm_env.block_env.coinbase;
+
+    let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
+
+    // apply eip-4788 pre block contract call
+    system_caller
+        .pre_block_beacon_root_contract_call(&mut db, &evm_env, attributes.parent_beacon_block_root)
+        .map_err(|err| {
+            warn!(target: "payload_builder",
+                parent_hash=%parent_header.hash(),
+                %err,
+                "failed to apply beacon root contract call for payload"
+            );
+            PayloadBuilderError::Internal(err.into())
+        })?;
+
+    // apply eip-2935 blockhashes update
+    system_caller.pre_block_blockhashes_contract_call(
+        &mut db,
+        &evm_env,
+        parent_header.hash(),
+    )
+    .map_err(|err| {
+        warn!(target: "payload_builder", parent_hash=%parent_header.hash(), %err, "failed to update parent header blockhashes for payload");
+        PayloadBuilderError::Internal(err.into())
+    })?;
+
+    let mut evm = evm_config.evm_with_env(&mut db, evm_env);
+
+    let mut receipts = Vec::new();
+    while let Some(pool_tx) = best_txs.next() {
+        // ensure we still have capacity for this transaction
+        if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
+            // we can't fit this transaction into the block, so we need to mark it as invalid
+            // which also removes all dependent transaction from the iterator before we can
+            // continue
+            best_txs.mark_invalid(
+                &pool_tx,
+                InvalidPoolTransactionError::ExceedsGasLimit(pool_tx.gas_limit(), block_gas_limit),
+            );
+            continue;
+        }
+
+        // check if the job was cancelled, if so we can exit early
+        if cancel.is_cancelled() {
+            return Ok(BuildOutcome::Cancelled);
+        }
+
+        // convert tx to a signed transaction
+        let tx = pool_tx.to_consensus();
+
+        // There's only limited amount of blob space available per block, so we need to check if
+        // the EIP-4844 can still fit in the block
+        if let Some(blob_tx) = tx.as_eip4844() {
+            let tx_blob_gas = blob_tx.blob_gas();
+            if sum_blob_gas_used + tx_blob_gas > MAX_DATA_GAS_PER_BLOCK {
+                // we can't fit this _blob_ transaction into the block, so we mark it as
+                // invalid, which removes its dependent transactions from
+                // the iterator. This is similar to the gas limit condition
+                // for regular transactions above.
+                trace!(target: "payload_builder", tx=?tx.hash, ?sum_blob_gas_used, ?tx_blob_gas, "skipping blob transaction because it would exceed the max data gas per block");
+                best_txs.mark_invalid(
+                    &pool_tx,
+                    InvalidPoolTransactionError::ExceedsGasLimit(
+                        tx_blob_gas,
+                        MAX_DATA_GAS_PER_BLOCK,
+                    ),
+                );
+                continue;
+            }
+        }
+
+        // Configure the environment for the tx.
+        let tx_env = evm_config.tx_env(tx.tx(), tx.signer());
+
+        let ResultAndState { result, state } = match evm.transact(tx_env) {
+            Ok(res) => res,
+            Err(err) => {
+                match err {
+                    EVMError::Transaction(err) => {
+                        if matches!(err, InvalidTransaction::NonceTooLow { .. }) {
+                            // if the nonce is too low, we can skip this transaction
+                            trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
+                        } else {
+                            // if the transaction is invalid, we can skip it and all of its
+                            // descendants
+                            trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                InvalidPoolTransactionError::Consensus(
+                                    InvalidTransactionError::TxTypeNotSupported,
+                                ),
+                            );
+                        }
+
+                        continue;
+                    }
+                    err => {
+                        // this is an error that we should treat as fatal for this attempt
+                        return Err(PayloadBuilderError::EvmExecutionError(err));
+                    }
+                }
+            }
+        };
+
+        // commit changes
+        evm.db_mut().commit(state);
+
+        // add to the total blob gas used if the transaction successfully executed
+        if let Some(blob_tx) = tx.as_eip4844() {
+            let tx_blob_gas = blob_tx.blob_gas();
+            sum_blob_gas_used += tx_blob_gas;
+
+            // if we've reached the max data gas per block, we can skip blob txs entirely
+            if sum_blob_gas_used == MAX_DATA_GAS_PER_BLOCK {
+                best_txs.skip_blobs();
+            }
+        }
+
+        let gas_used = result.gas_used();
+
+        // add gas used by the transaction to cumulative gas used, before creating the receipt
+        cumulative_gas_used += gas_used;
+
+        // Push transaction changeset and calculate header bloom filter for receipt.
+        #[allow(clippy::needless_update)] // side-effect of optimism fields
+        receipts.push(Some(Receipt {
+            tx_type: tx.tx_type(),
+            success: result.is_success(),
+            cumulative_gas_used,
+            logs: result.into_logs().into_iter().collect(),
+            ..Default::default()
+        }));
+
+        // update add to total fees
+        let miner_fee = tx
+            .effective_tip_per_gas(base_fee)
+            .expect("fee is always valid; execution succeeded");
+        total_fees += U256::from(miner_fee) * U256::from(gas_used);
+
+        // append sender and transaction to the respective lists
+        executed_senders.push(tx.signer());
+        executed_txs.push(tx.into_tx());
+    }
+
+    // check if we have a better block
+    if !is_better_payload(best_payload.as_ref(), total_fees) {
+        // Release db
+        drop(evm);
+
+        // can skip building the block
+        return Ok(BuildOutcome::Aborted {
+            fees: total_fees,
+            cached_reads,
+        });
+    }
+
+    // calculate the requests and the requests root
+    let requests = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
+        let deposit_requests = parse_deposits_from_receipts(&chain_spec, receipts.iter().flatten())
+            .map_err(|err| PayloadBuilderError::Internal(RethError::Execution(err.into())))?;
+
+        let mut requests = Requests::default();
+
+        if !deposit_requests.is_empty() {
+            requests.push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
+        }
+
+        requests.extend(
+            system_caller
+                .apply_post_execution_changes(&mut evm)
+                .map_err(|err| PayloadBuilderError::Internal(err.into()))?,
+        );
+
+        Some(requests)
+    } else {
+        None
+    };
+
+    // Release db
+    drop(evm);
+
+    let withdrawals_root = commit_withdrawals(
+        &mut db,
+        &chain_spec,
+        attributes.timestamp,
+        &attributes.withdrawals,
+    )?;
+
+    // merge all transitions into bundle state, this would apply the withdrawal balance changes
+    // and 4788 contract call
+    db.merge_transitions(BundleRetention::Reverts);
+
+    let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
+    let execution_outcome = ExecutionOutcome::new(
+        db.take_bundle(),
+        vec![receipts].into(),
+        block_number,
+        vec![requests.clone().unwrap_or_default()],
+    );
+    let receipts_root = execution_outcome
+        .ethereum_receipts_root(block_number)
+        .expect("Number is in range");
+    let logs_bloom = execution_outcome
+        .block_logs_bloom(block_number)
+        .expect("Number is in range");
+
+    // calculate the state root
+    let hashed_state = db.database.db.hashed_post_state(execution_outcome.state());
+    let (state_root, trie_output) = {
+        db.database
+            .inner()
+            .state_root_with_updates(hashed_state.clone())
+            .inspect_err(|err| {
+                warn!(target: "payload_builder",
+                    parent_hash=%parent_header.hash(),
+                    %err,
+                    "failed to calculate state root for payload"
+                );
+            })?
+    };
+
+    // create the block header
+    let transactions_root = calculate_transaction_root(&executed_txs);
+
+    // initialize empty blob sidecars at first. If cancun is active then this will
+    let mut blob_sidecars = Vec::new();
+    let mut excess_blob_gas = None;
+    let mut blob_gas_used = None;
+
+    // only determine cancun fields when active
+    if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp) {
+        // grab the blob sidecars from the executed txs
+        blob_sidecars = pool
+            .get_all_blobs_exact(
+                executed_txs
+                    .iter()
+                    .filter(|tx| tx.is_eip4844())
+                    .map(|tx| *tx.tx_hash())
+                    .collect(),
+            )
+            .map_err(PayloadBuilderError::other)?;
+
+        excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(parent_header.timestamp) {
+            let blob_params = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
+                BlobParams::prague()
+            } else {
+                // cancun
+                BlobParams::cancun()
+            };
+            parent_header.next_block_excess_blob_gas(blob_params)
+        } else {
+            // for the first post-fork block, both parent.blob_gas_used and
+            // parent.excess_blob_gas are evaluated as 0
+            Some(alloy_eips::eip4844::calc_excess_blob_gas(0, 0))
+        };
+
+        blob_gas_used = Some(sum_blob_gas_used);
+    }
+
+    let header = Header {
+        parent_hash: parent_header.hash(),
+        ommers_hash: EMPTY_OMMER_ROOT_HASH,
+        beneficiary,
+        state_root,
+        transactions_root,
+        receipts_root,
+        withdrawals_root,
+        logs_bloom,
+        timestamp: attributes.timestamp,
+        mix_hash: attributes.prev_randao,
+        nonce: BEACON_NONCE.into(),
+        base_fee_per_gas: Some(base_fee),
+        number: parent_header.number + 1,
+        gas_limit: block_gas_limit,
+        difficulty: U256::ZERO,
+        gas_used: cumulative_gas_used,
+        extra_data: builder_config.extra_data,
+        parent_beacon_block_root: attributes.parent_beacon_block_root,
+        blob_gas_used,
+        excess_blob_gas,
+        requests_hash,
+    };
+
+    let withdrawals = chain_spec
+        .is_shanghai_active_at_timestamp(attributes.timestamp)
+        .then(|| attributes.withdrawals.clone());
+
+    // seal the block
+    let block = Block {
+        header,
+        body: BlockBody {
+            transactions: executed_txs,
+            ommers: vec![],
+            withdrawals,
+        },
+    };
+
+    let sealed_block = Arc::new(block.seal_slow());
+    debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
+
+    // create the executed block data
+    let executed = ExecutedBlock {
+        recovered_block: Arc::new(RecoveredBlock::new_sealed(
+            sealed_block.as_ref().clone(),
+            executed_senders,
+        )),
+        execution_output: Arc::new(execution_outcome),
+        hashed_state: Arc::new(hashed_state),
+        trie: Arc::new(trie_output),
+    };
+
+    let mut payload = EthBuiltPayload::new(
+        attributes.id,
+        sealed_block,
+        total_fees,
+        Some(executed),
+        requests,
+    );
+
+    // extend the payload with the blob sidecars from the executed txs
+    payload.extend_sidecars(blob_sidecars.into_iter().map(Arc::unwrap_or_clone));
+
+    Ok(BuildOutcome::Better {
+        payload,
+        cached_reads,
+    })
 }


### PR DESCRIPTION
By adding the entire node builder flow, we gain access to the entire payload building flow (`MyPayloadBuilder::try_build()`) and execution flow (`MyExecutionStrategy::execute_transactions()`). This becomes necessary when we want to specify that we need to build the evm with an inspector.

For now all of the logic in these flow has been copied directly from the ethereum implementation in reth.