### PR TITLE
Double spend unlocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8920,7 +8920,6 @@ dependencies = [
 [[package]]
 name = "sova-sentinel-client"
 version = "0.1.0"
-source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8#ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8"
 dependencies = [
  "prost",
  "sova-sentinel-proto",
@@ -8932,7 +8931,6 @@ dependencies = [
 [[package]]
 name = "sova-sentinel-proto"
 version = "0.1.0"
-source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8#ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8920,6 +8920,7 @@ dependencies = [
 [[package]]
 name = "sova-sentinel-client"
 version = "0.1.0"
+source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=8a1aad2cc79ef5a294bf3075c9e57ce12b029f40#8a1aad2cc79ef5a294bf3075c9e57ce12b029f40"
 dependencies = [
  "prost",
  "sova-sentinel-proto",
@@ -8931,6 +8932,7 @@ dependencies = [
 [[package]]
 name = "sova-sentinel-proto"
 version = "0.1.0"
+source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=8a1aad2cc79ef5a294bf3075c9e57ce12b029f40#8a1aad2cc79ef5a294bf3075c9e57ce12b029f40"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,11 @@ sova-node = { path = "crates/node" }
 sova-payload = { path = "crates/payload" }
 
 # sova external
-sova-sentinel-client = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8" }
-sova-sentinel-proto = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8" }
+# sova-sentinel-client = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8" }
+# sova-sentinel-proto = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8" }
+
+sova-sentinel-client = { path="../sova-sentinel/crates/client" }
+sova-sentinel-proto = { path="../sova-sentinel/crates/proto" }
 
 # reth
 reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,8 @@ sova-node = { path = "crates/node" }
 sova-payload = { path = "crates/payload" }
 
 # sova external
-# sova-sentinel-client = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8" }
-# sova-sentinel-proto = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "ad57df2a7fbcca3434b43259b8e8a1dbb169fcb8" }
-
-sova-sentinel-client = { path="../sova-sentinel/crates/client" }
-sova-sentinel-proto = { path="../sova-sentinel/crates/proto" }
+sova-sentinel-client = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "8a1aad2cc79ef5a294bf3075c9e57ce12b029f40" }
+sova-sentinel-proto = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "8a1aad2cc79ef5a294bf3075c9e57ce12b029f40" }
 
 # reth
 reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -147,10 +147,9 @@ where
                 let prev_value = slot_data.previous_or_original_value;
 
                 // Load account from state
-                let acc = self
-                    .state
-                    .load_cache_account(*address)
-                    .map_err(|e| BlockExecutionError::Internal(InternalBlockExecutionError::msg(e)))?;
+                let acc = self.state.load_cache_account(*address).map_err(|e| {
+                    BlockExecutionError::Internal(InternalBlockExecutionError::msg(e))
+                })?;
 
                 // Ensure storage slot is explicitly set to previous_or_original_value
                 if let Some(a) = acc.account.as_mut() {

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -111,6 +111,7 @@ where
         let inspector_lock = self.evm_config.with_inspector();
         let mut inspector = inspector_lock.write();
         inspector.cache.clear_cache();
+        inspector.slot_revert_cache.clear();
 
         // Create EVM in inner scope
         let mut evm = self.evm_config.evm_with_env_and_inspector(
@@ -138,7 +139,7 @@ where
 
         drop(evm);
 
-        let revert_cache: Vec<(Address, TransitionAccount)> = inspector.take_slot_revert_cache();
+        let revert_cache: Vec<(Address, TransitionAccount)> = inspector.slot_revert_cache.clone();
 
         // apply mask to the database
         for (address, transition) in &revert_cache {
@@ -175,6 +176,7 @@ where
         let inspector_lock = self.evm_config.with_inspector();
         let mut inspector = inspector_lock.write();
         inspector.cache.clear_cache();
+        inspector.slot_revert_cache.clear();
 
         // Create EVM
         let mut evm = self.evm_config.evm_with_env_and_inspector(

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -3,7 +3,10 @@ use std::{fmt::Display, sync::Arc};
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::{eip6110, eip7685::Requests};
 
-use alloy_primitives::{map::foldhash::{HashMap, HashMapExt}, Address};
+use alloy_primitives::{
+    map::foldhash::{HashMap, HashMapExt},
+    Address,
+};
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_consensus::ConsensusError;
 use reth_ethereum_consensus::validate_block_post_execution;
@@ -153,7 +156,8 @@ where
                 }
 
                 // Convert to revm account, mark as modified and commit it to state
-                let mut revm_acc: Account = acc.account_info()
+                let mut revm_acc: Account = acc
+                    .account_info()
                     .ok_or(BlockExecutionError::Internal(
                         InternalBlockExecutionError::msg("failed to get account info"),
                     ))?

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -26,7 +26,6 @@ use reth_revm::{
     primitives::{Account, ResultAndState},
     Database, DatabaseCommit, TransitionAccount,
 };
-use reth_tracing::tracing::info;
 
 use crate::{inspector::WithInspector, MyEvmConfig};
 
@@ -104,14 +103,11 @@ where
         // Prepare EVM configuration
         let cfg_and_block_env = self.evm_config.cfg_and_block_env(block.header());
 
-        // SIMULATION PHASE
-        info!("SIMULATION PHASE");
+        // *** SIMULATION PHASE ***
 
         // Get inspector in inner scope
         let inspector_lock = self.evm_config.with_inspector();
         let mut inspector = inspector_lock.write();
-        inspector.cache.clear_cache();
-        inspector.slot_revert_cache.clear();
 
         // Create EVM in inner scope
         let mut evm = self.evm_config.evm_with_env_and_inspector(
@@ -168,14 +164,11 @@ where
 
         drop(inspector);
 
-        // EXECUTION PHASE
-        info!("EXECUTION PHASE");
+        // *** EXECUTION PHASE ***
 
         // Get inspector
         let inspector_lock = self.evm_config.with_inspector();
         let mut inspector = inspector_lock.write();
-        inspector.cache.clear_cache();
-        inspector.slot_revert_cache.clear();
 
         // Create EVM
         let mut evm = self.evm_config.evm_with_env_and_inspector(

--- a/crates/evm/src/inspector/error.rs
+++ b/crates/evm/src/inspector/error.rs
@@ -1,0 +1,38 @@
+use std::fmt;
+
+use tonic::transport::Error as TonicError;
+
+#[derive(Debug)]
+pub enum SlotProviderError {
+    Transport(TonicError),
+    RpcError(String),
+    ConnectionError(String),
+    BitcoinError(bitcoincore_rpc::Error),
+}
+
+impl fmt::Display for SlotProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SlotProviderError::Transport(e) => write!(f, "Transport error: {}", e),
+            SlotProviderError::RpcError(e) => write!(f, "RPC error: {}", e),
+            SlotProviderError::ConnectionError(e) => write!(f, "Connection error: {}", e),
+            SlotProviderError::BitcoinError(e) => write!(f, "Bitcoin error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for SlotProviderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SlotProviderError::Transport(e) => Some(e),
+            SlotProviderError::RpcError(_) | SlotProviderError::ConnectionError(_) => None,
+            SlotProviderError::BitcoinError(e) => Some(e),
+        }
+    }
+}
+
+impl From<TonicError> for SlotProviderError {
+    fn from(err: TonicError) -> Self {
+        Self::Transport(err)
+    }
+}

--- a/crates/evm/src/inspector/mod.rs
+++ b/crates/evm/src/inspector/mod.rs
@@ -1,10 +1,13 @@
+mod error;
 mod provider;
 mod storage_cache;
 
-pub use provider::SlotProvider;
-use provider::{SlotProviderError, StorageSlotProvider};
+use error::SlotProviderError;
+use provider::StorageSlotProvider;
 use reth_tasks::TaskExecutor;
 use sova_sentinel_proto::proto::{get_slot_status_response::Status, GetSlotStatusResponse};
+
+pub use provider::SlotProvider;
 pub use storage_cache::{AccessedStorage, BroadcastResult, StorageCache};
 
 use core::ops::Range;

--- a/crates/evm/src/inspector/mod.rs
+++ b/crates/evm/src/inspector/mod.rs
@@ -100,11 +100,11 @@ impl SovaInspector {
                 (broadcast_result.txid.as_ref(), broadcast_result.block)
             {
                 // Lock the storage with this transaction's details
-                self.storage_slot_provider.lock_slots(
+                self.storage_slot_provider.batch_lock_slots(
                     accessed_storage.clone(),
                     sova_block_number,
-                    btc_txid.clone(),
                     btc_block,
+                    btc_txid.clone(),
                 )?;
             }
         }
@@ -223,13 +223,13 @@ impl SovaInspector {
         };
 
         // check if any of the storage slots in broadcast_accessed_storage are locked
-        match self.storage_slot_provider.get_locked_status(
+        match self.storage_slot_provider.batch_get_locked_status(
             &self.cache.broadcast_accessed_storage,
             context.env.block.number.saturating_to(),
             current_btc_block_height,
         ) {
-            Ok(responses) => {
-                for response in responses {
+            Ok(batch_response) => {
+                for response in batch_response.slots {
                     debug!("GetSlotStatusResponse: {:?}", response);
 
                     let status = match Status::try_from(response.status) {

--- a/crates/evm/src/inspector/mod.rs
+++ b/crates/evm/src/inspector/mod.rs
@@ -86,8 +86,11 @@ impl SovaInspector {
 
         // Handle unlocking of reverted slots
         if !self.slot_revert_cache.is_empty() {
-            self.storage_slot_provider
-                .unlock_slot(current_btc_block_height, self.slot_revert_cache.clone())?;
+            self.storage_slot_provider.batch_unlock_slot(
+                sova_block_number,
+                current_btc_block_height,
+                self.slot_revert_cache.clone(),
+            )?;
         }
 
         // Handle locking of storage slots for each btc broadcast transaction
@@ -222,6 +225,7 @@ impl SovaInspector {
         // check if any of the storage slots in broadcast_accessed_storage are locked
         match self.storage_slot_provider.get_locked_status(
             &self.cache.broadcast_accessed_storage,
+            context.env.block.number.saturating_to(),
             current_btc_block_height,
         ) {
             Ok(responses) => {

--- a/crates/evm/src/inspector/mod.rs
+++ b/crates/evm/src/inspector/mod.rs
@@ -74,27 +74,7 @@ impl SovaInspector {
         &mut self,
         sova_block_number: u64,
     ) -> Result<(), SlotProviderError> {
-        // get current btc block height
-        // TODO: optimize btc block height handling/storage/reference
-        let current_btc_block_height = match self.btc_client.get_block_height() {
-            Ok(height) => height,
-            Err(err) => {
-                warn!("ERROR: Failed to get current btc block height: {}", err);
-                return Err(SlotProviderError::BitcoinError(err));
-            }
-        };
-
-        // Handle unlocking of reverted slots
-        if !self.slot_revert_cache.is_empty() {
-            self.storage_slot_provider.batch_unlock_slot(
-                sova_block_number,
-                current_btc_block_height,
-                self.slot_revert_cache.clone(),
-            )?;
-        }
-
         // Handle locking of storage slots for each btc broadcast transaction
-        // TODO: different source of block height being used in the lock_slots flow here
         for (broadcast_result, accessed_storage) in self.cache.lock_data.iter() {
             if let (Some(btc_txid), Some(btc_block)) =
                 (broadcast_result.txid.as_ref(), broadcast_result.block)

--- a/crates/evm/src/inspector/mod.rs
+++ b/crates/evm/src/inspector/mod.rs
@@ -15,7 +15,9 @@ use parking_lot::RwLock;
 use alloy_primitives::{Address, Bytes, U256};
 
 use reth_revm::{
-    db::{states::StorageSlot, AccountStatus, StorageWithOriginalValues}, interpreter::{CallInputs, CallOutcome, Gas, InstructionResult, InterpreterResult}, Database, EvmContext, Inspector, JournalEntry, TransitionAccount
+    db::{states::StorageSlot, AccountStatus, StorageWithOriginalValues},
+    interpreter::{CallInputs, CallOutcome, Gas, InstructionResult, InterpreterResult},
+    Database, EvmContext, Inspector, JournalEntry, TransitionAccount,
 };
 use reth_tracing::tracing::info;
 
@@ -66,7 +68,10 @@ impl SovaInspector {
     }
 
     /// Unlock all revereted storage slots and lock all accessed storage slots atend of execution
-    pub fn update_sentinel_locks(&mut self, sova_block_number: u64) -> Result<(), SlotProviderError> {
+    pub fn update_sentinel_locks(
+        &mut self,
+        sova_block_number: u64,
+    ) -> Result<(), SlotProviderError> {
         // get current btc block height
         // TODO: optimize btc block height handling/storage/reference
         let current_btc_block_height = match self.btc_client.get_block_height() {
@@ -106,7 +111,7 @@ impl SovaInspector {
 
         Ok(())
     }
-    
+
     /// Parse the Bitcoin method from input data
     fn get_btc_precompile_method(input: &Bytes) -> Result<BitcoinMethod, MethodError> {
         BitcoinMethod::try_from(input)
@@ -270,7 +275,7 @@ impl SovaInspector {
             }
         }
     }
-    
+
     // Parse revert info from the sentinel and update the revert cache
     fn handle_revert_status(&mut self, response: GetSlotStatusResponse) {
         // Parse contract address
@@ -314,7 +319,7 @@ impl SovaInspector {
         // Add to transition state
         self.slot_revert_cache.push((address, transition));
     }
-    
+
     /// Triggered at the end of any execution step that is a
     /// CALL, CALLCODE, DELEGATECALL, or STATICCALL opcode
     /// This inspector hook is primarily used for locking accessed

--- a/crates/evm/src/inspector/mod.rs
+++ b/crates/evm/src/inspector/mod.rs
@@ -43,7 +43,7 @@ pub struct SovaInspector {
     /// btc client
     btc_client: Arc<BitcoinClient>,
     /// transition state for sentinel reverts
-    slot_revert_cache: Vec<(Address, TransitionAccount)>,
+    pub slot_revert_cache: Vec<(Address, TransitionAccount)>,
 }
 
 impl SovaInspector {
@@ -63,10 +63,6 @@ impl SovaInspector {
             btc_client,
             slot_revert_cache: Vec::new(),
         })
-    }
-
-    pub fn take_slot_revert_cache(&mut self) -> Vec<(Address, TransitionAccount)> {
-        std::mem::take(&mut self.slot_revert_cache)
     }
 
     /// Unlock all revereted storage slots and lock all accessed storage slots atend of execution

--- a/crates/evm/src/inspector/provider.rs
+++ b/crates/evm/src/inspector/provider.rs
@@ -1,50 +1,9 @@
-use std::fmt;
-
-use alloy_primitives::Address;
-use reth_revm::TransitionAccount;
 use reth_tasks::TaskExecutor;
 
-use tonic::transport::Error as TonicError;
-
 use sova_sentinel_client::SlotLockClient;
-use sova_sentinel_proto::proto::BatchGetSlotStatusResponse;
+use sova_sentinel_proto::proto::{BatchGetSlotStatusResponse, SlotData};
 
-use super::storage_cache::AccessedStorage;
-
-#[derive(Debug)]
-pub enum SlotProviderError {
-    Transport(TonicError),
-    RpcError(String),
-    ConnectionError(String),
-    BitcoinError(bitcoincore_rpc::Error),
-}
-
-impl fmt::Display for SlotProviderError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SlotProviderError::Transport(e) => write!(f, "Transport error: {}", e),
-            SlotProviderError::RpcError(e) => write!(f, "RPC error: {}", e),
-            SlotProviderError::ConnectionError(e) => write!(f, "Connection error: {}", e),
-            SlotProviderError::BitcoinError(e) => write!(f, "Bitcoin error: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for SlotProviderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            SlotProviderError::Transport(e) => Some(e),
-            SlotProviderError::RpcError(_) | SlotProviderError::ConnectionError(_) => None,
-            SlotProviderError::BitcoinError(e) => Some(e),
-        }
-    }
-}
-
-impl From<TonicError> for SlotProviderError {
-    fn from(err: TonicError) -> Self {
-        Self::Transport(err)
-    }
-}
+use super::{error::SlotProviderError, storage_cache::AccessedStorage};
 
 pub trait SlotProvider {
     /// Get the lock status of the provided accessed storage slots
@@ -61,14 +20,6 @@ pub trait SlotProvider {
         block: u64,
         btc_block: u64,
         btc_txid: Vec<u8>,
-    ) -> Result<(), SlotProviderError>;
-    /// EXPERIMENTAL: Unlock the provided accessed storage slots
-    /// TODO: Rely in laxy unlocking in sentinel
-    fn batch_unlock_slot(
-        &self,
-        block: u64,
-        btc_block: u64,
-        transitions: Vec<(Address, TransitionAccount)>,
     ) -> Result<(), SlotProviderError>;
 }
 
@@ -128,49 +79,19 @@ impl StorageSlotProvider {
         // Process each account in the accessed cache
         for (address, slots) in storage.iter() {
             for (slot, slot_data) in slots {
-                slots_to_lock.push(sova_sentinel_proto::proto::SlotData {
-                    contract_address: address.to_string(),
-                    slot_index: slot.to_vec(),
-                    revert_value: slot_data.previous_value.to_be_bytes_vec(),
-                    current_value: slot_data.current_value.to_be_bytes_vec(),
-                });
+                slots_to_lock.push(
+                    SlotData {
+                        contract_address: address.to_string(),
+                        slot_index: slot.to_vec(),
+                        revert_value: slot_data.previous_value.to_be_bytes_vec(),
+                        current_value: slot_data.current_value.to_be_bytes_vec(),
+                    }
+                );
             }
         }
 
         match client
             .batch_lock_slot(block, btc_block, &hex::encode(&btc_txid), slots_to_lock)
-            .await
-            .map_err(|e| SlotProviderError::RpcError(e.to_string()))
-        {
-            Ok(_) => Ok(()),
-            // TODO: is the this best error handling?
-            Err(e) => return Err(SlotProviderError::RpcError(e.to_string())),
-        }
-    }
-
-    async fn batch_unlock_slots_inner(
-        client: &mut SlotLockClient,
-        block: u64,
-        btc_block: u64,
-        transitions: &[(Address, TransitionAccount)],
-    ) -> Result<(), SlotProviderError> {
-        let mut unlocked_slots: Vec<(String, Vec<u8>)> = Vec::new();
-
-        // Process each account in the revert cache
-        for (address, transition) in transitions.iter() {
-            // Only process accounts that have storage changes
-            if !transition.storage.is_empty() {
-                // Convert each storage slot to bytes and unlock it
-                for (slot, _) in transition.storage.iter() {
-                    let slot_bytes = slot.to_be_bytes_vec();
-
-                    unlocked_slots.push((address.to_string(), slot_bytes));
-                }
-            }
-        }
-
-        match client
-            .batch_unlock_slot(block, btc_block, unlocked_slots)
             .await
             .map_err(|e| SlotProviderError::RpcError(e.to_string()))
         {
@@ -219,26 +140,6 @@ impl SlotProvider for StorageSlotProvider {
                     .map_err(|e| SlotProviderError::ConnectionError(e.to_string()))?;
 
                 Self::batch_lock_slots_inner(&mut client, storage, block, btc_block, btc_txid).await
-            })
-        })
-    }
-
-    fn batch_unlock_slot(
-        &self,
-        block: u64,
-        btc_block: u64,
-        transitions: Vec<(Address, TransitionAccount)>,
-    ) -> Result<(), SlotProviderError> {
-        let sentinel_url = self.sentinel_url.clone();
-
-        tokio::task::block_in_place(|| {
-            let handle = self.task_executor.handle().clone();
-            handle.block_on(async {
-                let mut client = SlotLockClient::connect(sentinel_url)
-                    .await
-                    .map_err(|e| SlotProviderError::ConnectionError(e.to_string()))?;
-
-                Self::batch_unlock_slots_inner(&mut client, block, btc_block, &transitions).await
             })
         })
     }

--- a/crates/evm/src/inspector/provider.rs
+++ b/crates/evm/src/inspector/provider.rs
@@ -4,6 +4,7 @@ use alloy_primitives::Address;
 use reth_revm::TransitionAccount;
 use reth_tasks::TaskExecutor;
 
+use reth_tracing::tracing::info;
 use tonic::transport::Error as TonicError;
 
 use sova_sentinel_client::SlotLockClient;
@@ -116,16 +117,7 @@ impl StorageSlotProvider {
     ) -> Result<(), SlotProviderError> {
         for (address, slots) in storage.iter() {
             for (slot, slot_data) in slots {
-                println!(
-                    "Revert value: {:?}, Bytes: {:?}",
-                    slot_data.previous_value,
-                    slot_data.previous_value.to_be_bytes_vec()
-                );
-                println!(
-                    "Current value: {:?}, Bytes: {:?}",
-                    slot_data.current_value,
-                    slot_data.current_value.to_be_bytes_vec()
-                );
+                info!("Locking slot in sentinel: {} {} {:?}", address, slot, slot_data);
 
                 let _: LockSlotResponse = client
                     .lock_slot(
@@ -156,6 +148,8 @@ impl StorageSlotProvider {
             if !transition.storage.is_empty() {
                 // Convert each storage slot to bytes and unlock it
                 for (slot, _) in transition.storage.iter() {
+                    info!("Unlocking slot in sentinel: {} {}", address, slot);
+
                     let slot_bytes = slot.to_be_bytes_vec();
 
                     let _ = client

--- a/crates/evm/src/inspector/provider.rs
+++ b/crates/evm/src/inspector/provider.rs
@@ -63,7 +63,7 @@ impl StorageSlotProvider {
         {
             Ok(res) => Ok(res),
             // TODO: is the this best error handling?
-            Err(e) => return Err(SlotProviderError::RpcError(e.to_string())),
+            Err(e) => Err(SlotProviderError::RpcError(e.to_string()))
         }
     }
 
@@ -79,14 +79,12 @@ impl StorageSlotProvider {
         // Process each account in the accessed cache
         for (address, slots) in storage.iter() {
             for (slot, slot_data) in slots {
-                slots_to_lock.push(
-                    SlotData {
-                        contract_address: address.to_string(),
-                        slot_index: slot.to_vec(),
-                        revert_value: slot_data.previous_value.to_be_bytes_vec(),
-                        current_value: slot_data.current_value.to_be_bytes_vec(),
-                    }
-                );
+                slots_to_lock.push(SlotData {
+                    contract_address: address.to_string(),
+                    slot_index: slot.to_vec(),
+                    revert_value: slot_data.previous_value.to_be_bytes_vec(),
+                    current_value: slot_data.current_value.to_be_bytes_vec(),
+                });
             }
         }
 
@@ -97,7 +95,7 @@ impl StorageSlotProvider {
         {
             Ok(_) => Ok(()),
             // TODO: is the this best error handling?
-            Err(e) => return Err(SlotProviderError::RpcError(e.to_string())),
+            Err(e) => Err(SlotProviderError::RpcError(e.to_string()))
         }
     }
 }

--- a/crates/evm/src/inspector/provider.rs
+++ b/crates/evm/src/inspector/provider.rs
@@ -117,7 +117,10 @@ impl StorageSlotProvider {
     ) -> Result<(), SlotProviderError> {
         for (address, slots) in storage.iter() {
             for (slot, slot_data) in slots {
-                info!("Locking slot in sentinel: {} {} {:?}", address, slot, slot_data);
+                info!(
+                    "Locking slot in sentinel: {} {} {:?}",
+                    address, slot, slot_data
+                );
 
                 let _: LockSlotResponse = client
                     .lock_slot(

--- a/crates/evm/src/inspector/provider.rs
+++ b/crates/evm/src/inspector/provider.rs
@@ -50,7 +50,7 @@ pub trait SlotProvider {
     /// Provided accessed storage slots, return boolean indicating if all slots are unlocked or not
     fn get_locked_status(
         &self,
-        storage: AccessedStorage,
+        storage: &AccessedStorage,
         block: u64,
     ) -> Result<Vec<GetSlotStatusResponse>, SlotProviderError>;
     /// Lock the provided accessed storage slots with the corresponding bitcoin txid and vout
@@ -90,7 +90,7 @@ impl StorageSlotProvider {
     async fn get_locked_status_inner(
         client: &mut SlotLockClient,
         block: u64,
-        storage: AccessedStorage,
+        storage: &AccessedStorage,
     ) -> Result<Vec<GetSlotStatusResponse>, SlotProviderError> {
         let mut responses = Vec::new();
         for (address, slots) in storage.iter() {
@@ -162,7 +162,7 @@ impl StorageSlotProvider {
 impl SlotProvider for StorageSlotProvider {
     fn get_locked_status(
         &self,
-        storage: AccessedStorage,
+        storage: &AccessedStorage,
         block: u64,
     ) -> Result<Vec<GetSlotStatusResponse>, SlotProviderError> {
         let sentinel_url = self.sentinel_url.clone();

--- a/crates/evm/src/inspector/provider.rs
+++ b/crates/evm/src/inspector/provider.rs
@@ -63,7 +63,7 @@ impl StorageSlotProvider {
         {
             Ok(res) => Ok(res),
             // TODO: is the this best error handling?
-            Err(e) => Err(SlotProviderError::RpcError(e.to_string()))
+            Err(e) => Err(SlotProviderError::RpcError(e.to_string())),
         }
     }
 
@@ -95,7 +95,7 @@ impl StorageSlotProvider {
         {
             Ok(_) => Ok(()),
             // TODO: is the this best error handling?
-            Err(e) => Err(SlotProviderError::RpcError(e.to_string()))
+            Err(e) => Err(SlotProviderError::RpcError(e.to_string())),
         }
     }
 }

--- a/crates/evm/src/inspector/provider.rs
+++ b/crates/evm/src/inspector/provider.rs
@@ -4,7 +4,6 @@ use alloy_primitives::Address;
 use reth_revm::TransitionAccount;
 use reth_tasks::TaskExecutor;
 
-use reth_tracing::tracing::info;
 use tonic::transport::Error as TonicError;
 
 use sova_sentinel_client::SlotLockClient;
@@ -117,11 +116,6 @@ impl StorageSlotProvider {
     ) -> Result<(), SlotProviderError> {
         for (address, slots) in storage.iter() {
             for (slot, slot_data) in slots {
-                info!(
-                    "Locking slot in sentinel: {} {} {:?}",
-                    address, slot, slot_data
-                );
-
                 let _: LockSlotResponse = client
                     .lock_slot(
                         block,
@@ -151,8 +145,6 @@ impl StorageSlotProvider {
             if !transition.storage.is_empty() {
                 // Convert each storage slot to bytes and unlock it
                 for (slot, _) in transition.storage.iter() {
-                    info!("Unlocking slot in sentinel: {} {}", address, slot);
-
                     let slot_bytes = slot.to_be_bytes_vec();
 
                     let _ = client

--- a/crates/evm/src/inspector/storage_cache.rs
+++ b/crates/evm/src/inspector/storage_cache.rs
@@ -131,8 +131,12 @@ impl StorageCache {
                 };
 
                 // If we don't have an entry for this address and key, add one
-                self.broadcast_accessed_storage
-                    .insert(address, key, previous_value.unwrap_or_default(), storage_change.value);
+                self.broadcast_accessed_storage.insert(
+                    address,
+                    key,
+                    previous_value.unwrap_or_default(),
+                    storage_change.value,
+                );
             }
         }
     }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -6,7 +6,7 @@ mod precompiles;
 use constants::BTC_PRECOMPILE_ADDRESS;
 pub use execute::MyExecutionStrategyFactory;
 use inspector::SovaInspector;
-pub use inspector::{AccessedStorage, BroadcastResult, SlotProvider, WithInspector};
+pub use inspector::{AccessedStorage, BroadcastResult, SlotProvider, StorageChange, WithInspector};
 pub use precompiles::BitcoinClient;
 use precompiles::BitcoinRpcPrecompile;
 

--- a/crates/evm/src/precompiles/mod.rs
+++ b/crates/evm/src/precompiles/mod.rs
@@ -2,7 +2,7 @@ mod abi;
 mod btc_client;
 mod precompile_utils;
 
-pub use precompile_utils::{BitcoinMethod, MethodError};
+pub use precompile_utils::BitcoinMethod;
 use reth_tracing::tracing::{info, warn};
 
 use std::sync::Arc;

--- a/crates/evm/src/precompiles/mod.rs
+++ b/crates/evm/src/precompiles/mod.rs
@@ -178,14 +178,17 @@ impl BitcoinRpcPrecompile {
             })?;
 
         if broadcast_response.status != "success" {
-            info!("Broadcast btc tx precompile error: {:?}", broadcast_response.error);
+            info!(
+                "Broadcast btc tx precompile error: {:?}",
+                broadcast_response.error
+            );
             return Err(PrecompileErrors::Error(PrecompileError::Other(
                 broadcast_response
                     .error
                     .unwrap_or_else(|| "Broadcast service error".into()),
             )));
         } else {
-            let txid_str = hex::encode(&broadcast_response.txid.clone().unwrap());
+            let txid_str = hex::encode(broadcast_response.txid.clone().unwrap());
             info!("Broadcast bitcoin txid: {}", txid_str);
         }
 

--- a/crates/evm/src/precompiles/mod.rs
+++ b/crates/evm/src/precompiles/mod.rs
@@ -3,7 +3,7 @@ mod btc_client;
 mod precompile_utils;
 
 pub use precompile_utils::{BitcoinMethod, MethodError};
-use reth_tracing::tracing::info;
+use reth_tracing::tracing::{info, warn};
 
 use std::sync::Arc;
 
@@ -170,7 +170,7 @@ impl BitcoinRpcPrecompile {
                 Some(&broadcast_request),
             )
             .map_err(|e| {
-                info!("HTTP request to broadcast service failed: {}", e);
+                warn!("WARNING: HTTP request to broadcast service failed: {}", e);
                 PrecompileErrors::Error(PrecompileError::Other(format!(
                     "HTTP request to broadcast service failed: {}",
                     e
@@ -178,8 +178,8 @@ impl BitcoinRpcPrecompile {
             })?;
 
         if broadcast_response.status != "success" {
-            info!(
-                "Broadcast btc tx precompile error: {:?}",
+            warn!(
+                "WARNING: Broadcast btc tx precompile error: {:?}",
                 broadcast_response.error
             );
             return Err(PrecompileErrors::Error(PrecompileError::Other(
@@ -197,7 +197,7 @@ impl BitcoinRpcPrecompile {
 
         // Get txid bytes directly from the response
         let txid_bytes = broadcast_response.txid.ok_or_else(|| {
-            info!("No txid in broadcast response");
+            warn!("No txid in broadcast response");
             PrecompileErrors::Error(PrecompileError::Other(
                 "No txid in broadcast response".into(),
             ))

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -228,6 +228,7 @@ where
     let inspector_lock = evm_config.with_inspector();
     let mut inspector = inspector_lock.write();
     inspector.cache.clear_cache();
+    inspector.slot_revert_cache.clear();
 
     // Create EVM
     let mut evm = evm_config.evm_with_env_and_inspector(&mut db, evm_env.clone(), &mut *inspector);
@@ -279,7 +280,7 @@ where
 
     drop(evm);
 
-    let revert_cache: Vec<(Address, TransitionAccount)> = inspector.take_slot_revert_cache();
+    let revert_cache: Vec<(Address, TransitionAccount)> = inspector.slot_revert_cache.clone();
 
     // apply mask to the database
     for (address, transition) in &revert_cache {
@@ -319,6 +320,7 @@ where
     let inspector_lock = evm_config.with_inspector();
     let mut inspector = inspector_lock.write();
     inspector.cache.clear_cache();
+    inspector.slot_revert_cache.clear();
 
     // Create EVM
     let mut evm = evm_config.evm_with_env_and_inspector(&mut db, evm_env.clone(), &mut *inspector);

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -35,7 +35,7 @@ use reth_revm::{
     primitives::{Account, EVMError, InvalidTransaction, ResultAndState},
     DatabaseCommit, TransitionAccount,
 };
-use reth_tracing::tracing::{debug, info, trace, warn};
+use reth_tracing::tracing::{debug, trace, warn};
 use reth_transaction_pool::{
     error::InvalidPoolTransactionError, noop::NoopTransactionPool, BestTransactions,
     BestTransactionsAttributes, PoolTransaction, TransactionPool, ValidPoolTransaction,
@@ -221,14 +221,11 @@ where
         PayloadBuilderError::Internal(err.into())
     })?;
 
-    // SIMULATION PHASE
-    info!("SIMULATION PHASE");
+    // *** SIMULATION PHASE ***
 
     // Get inspector
     let inspector_lock = evm_config.with_inspector();
     let mut inspector = inspector_lock.write();
-    inspector.cache.clear_cache();
-    inspector.slot_revert_cache.clear();
 
     // Create EVM
     let mut evm = evm_config.evm_with_env_and_inspector(&mut db, evm_env.clone(), &mut *inspector);
@@ -313,14 +310,11 @@ where
 
     drop(inspector);
 
-    // EXECUTION PHASE
-    info!("EXECUTION PHASE");
+    // *** EXECUTION PHASE ***
 
     // Get inspector
     let inspector_lock = evm_config.with_inspector();
     let mut inspector = inspector_lock.write();
-    inspector.cache.clear_cache();
-    inspector.slot_revert_cache.clear();
 
     // Create EVM
     let mut evm = evm_config.evm_with_env_and_inspector(&mut db, evm_env.clone(), &mut *inspector);

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -5,7 +5,10 @@ use alloy_eips::{
     eip4844::MAX_DATA_GAS_PER_BLOCK, eip6110, eip7685::Requests, eip7840::BlobParams,
     merge::BEACON_NONCE,
 };
-use alloy_primitives::{map::foldhash::{HashMap, HashMapExt}, Address, U256};
+use alloy_primitives::{
+    map::foldhash::{HashMap, HashMapExt},
+    Address, U256,
+};
 
 use reth_basic_payload_builder::{
     commit_withdrawals, is_better_payload, BuildArguments, BuildOutcome, PayloadBuilder,
@@ -300,18 +303,17 @@ where
             }
 
             // Convert to revm account, mark as modified and commit it to state
-            let mut revm_acc: Account = acc.account_info()
-                .ok_or(
-                    PayloadBuilderError::Internal(
-                        RethError::msg("failed to convert account to revm account")
-                    )
-                )?
+            let mut revm_acc: Account = acc
+                .account_info()
+                .ok_or(PayloadBuilderError::Internal(RethError::msg(
+                    "failed to convert account to revm account",
+                )))?
                 .into();
 
             revm_acc.mark_touch();
 
             let mut changes: HashMap<Address, Account> = HashMap::new();
-                changes.insert(*address, revm_acc);
+            changes.insert(*address, revm_acc);
 
             // commit to account slot changes to state
             db.commit(changes);

--- a/scripts/dev-double-spend-test-transfer.sh
+++ b/scripts/dev-double-spend-test-transfer.sh
@@ -80,10 +80,9 @@ cast send \
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
-
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
-        "totalSupply()")
+        "totalSupply()" | cast to-dec)
 
     echo "Balance: $BALANCE"
     echo "Total Supply: $TOTAL_SUPPLY"
@@ -104,10 +103,9 @@ cast send \
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
-
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
-        "totalSupply()")
+        "totalSupply()" | cast to-dec)
 
     echo "Balance: $BALANCE"
     echo "Total Supply: $TOTAL_SUPPLY"
@@ -126,5 +124,15 @@ cast send \
     "transfer(address,uint256)" \
     "0x70997970C51812dc3A010C7d01b50e0d17dc79C8" \
     "100"
+
+echo "Checking contract state..."
+    BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "balanceOf(address)" \
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
+    TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "totalSupply()" | cast to-dec)
+
+    echo "Balance: $BALANCE"
+    echo "Total Supply: $TOTAL_SUPPLY"
 
 echo "Done!"

--- a/scripts/dev-double-spend-test-transfer.sh
+++ b/scripts/dev-double-spend-test-transfer.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Resources:
+# https://github.com/PowVT/satoshi-suite
+# https://github.com/SovaNetwork/running-sova
+# https://github.com/foundry-rs
+
+# This script tests double-spend functionality for a dev sova-reth node using bitcoin regtest
+#
+# It:
+# 1. Creates onr Bitcoin transaction, with 0.001 BTC fee
+# 2. Submits the BTC transaction to uBTC contract for deposit
+# 3. Test transfer of uBTC to another user. This should fail and enforce the locks places on the slots.
+# 4. Check the balanceOf user and total supply slots in the sova uBTC smart contract
+
+# Exit on error
+set -e
+
+# Configuration
+WALLET_1="user"
+WALLET_2="miner"
+UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q8pw3u88q56mfdqhxyeu0a7fesddq8jwsxxqng8"
+DOUBLE_SPEND_RECEIVE_ADDRESS="bcrt1q6xxa0arlrk6jdz02alxc6smdv5g953v7zkswaw" # random address for double spend
+ETH_RPC_URL="http://localhost:8545"
+ETH_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+CHAIN_ID="120893"
+
+# Function to convert BTC to smallest unit (satoshis)
+btc_to_sats() {
+    echo "$1 * 100000000" | bc | cut -d'.' -f1
+}
+
+# Function to extract transaction hex
+get_tx_hex() {
+    local output=$1
+    local hex=$(echo "$output" | grep "Signed transaction:" | sed 's/.*Signed transaction: //')
+    echo "$hex"
+}
+
+echo "Creating Bitcoin wallets..."
+satoshi-suite new-wallet --wallet-name "$WALLET_1"
+satoshi-suite new-wallet --wallet-name "$WALLET_2"
+
+echo "Mining initial blocks..."
+satoshi-suite mine-blocks --wallet-name "$WALLET_1" --blocks 1
+satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 100
+
+echo "Creating Bitcoin transactions..."
+# Transaction with 0.001 fee
+TX1_OUTPUT=$(satoshi-suite sign-tx --wallet-name "$WALLET_1" --recipient "$UBTC_BITCOIN_RECEIVE_ADDRESS" --amount 49.999 --fee-amount 0.001)
+TX1_HEX=$(get_tx_hex "$TX1_OUTPUT")
+
+# For debugging
+echo "TX1 Hex: $TX1_HEX"
+
+echo "Deploying uBTC contract..."
+cd ~/contracts
+DEPLOY_OUTPUT=$(forge create --rpc-url http://localhost:8545 --broadcast \
+    --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+    src/uBTC.sol:uBTC)
+CONTRACT_ADDRESS=$(echo "$DEPLOY_OUTPUT" | grep "Deployed to:" | cut -d' ' -f3)
+echo "Contract deployed to: $CONTRACT_ADDRESS"
+
+cd ~
+
+# Convert 49.999 BTC to satoshis
+AMOUNT_SATS=$(btc_to_sats 49.999)
+
+echo "Submitting first transaction to Ethereum contract (0.001 fee)..."
+cast send \
+    --rpc-url "$ETH_RPC_URL" \
+    --private-key "$ETH_PRIVATE_KEY" \
+    --gas-limit 250000 \
+    --chain-id "$CHAIN_ID" \
+    "$CONTRACT_ADDRESS" \
+    "depositBTC(uint256,bytes)" \
+    "$AMOUNT_SATS" \
+    "0x$TX1_HEX"
+
+echo "Checking contract state..."
+    BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "balanceOf(address)" \
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+
+    TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "totalSupply()")
+
+    echo "Balance: $BALANCE"
+    echo "Total Supply: $TOTAL_SUPPLY"
+
+echo "Submitting erc20 transfer() call (should fail)..."
+
+# This should fail
+cast send \
+    --rpc-url "$ETH_RPC_URL" \
+    --private-key "$ETH_PRIVATE_KEY" \
+    --gas-limit 100000 \
+    --chain-id "$CHAIN_ID" \
+    "$CONTRACT_ADDRESS" \
+    "transfer(address,uint256)" \
+    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8" \
+    "100"
+
+echo "Checking contract state..."
+    BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "balanceOf(address)" \
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+
+    TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "totalSupply()")
+
+    echo "Balance: $BALANCE"
+    echo "Total Supply: $TOTAL_SUPPLY"
+
+echo "mining blocks to conifirm btc tx..."
+satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 7
+
+echo "Submitting erc20 transfer() call (should succeed)..."
+
+cast send \
+    --rpc-url "$ETH_RPC_URL" \
+    --private-key "$ETH_PRIVATE_KEY" \
+    --gas-limit 100000 \
+    --chain-id "$CHAIN_ID" \
+    "$CONTRACT_ADDRESS" \
+    "transfer(address,uint256)" \
+    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8" \
+    "100"
+
+echo "Done!"

--- a/scripts/dev-double-spend-test-withdraw.sh
+++ b/scripts/dev-double-spend-test-withdraw.sh
@@ -101,10 +101,9 @@ satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 100
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
-
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
-        "totalSupply()")
+        "totalSupply()" | cast to-dec)
 
     echo "Balance: $BALANCE"
     echo "Total Supply: $TOTAL_SUPPLY"
@@ -127,10 +126,9 @@ cast send \
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
-
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
-        "totalSupply()")
+        "totalSupply()" | cast to-dec)
 
     echo "Balance: $BALANCE"
     echo "Total Supply: $TOTAL_SUPPLY"
@@ -188,10 +186,9 @@ cast send \
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
-
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
-        "totalSupply()")
+        "totalSupply()" | cast to-dec)
 
     echo "Balance: $BALANCE"
     echo "Total Supply: $TOTAL_SUPPLY"

--- a/scripts/dev-double-spend-test-withdraw.sh
+++ b/scripts/dev-double-spend-test-withdraw.sh
@@ -9,9 +9,9 @@
 #
 # It:
 # 1. Creates two Bitcoin transactions spending the same UTXO:
-#    - First with 0.001 BTC fee (used for Ethereum deposit)
+#    - First with 0.001 BTC fee
 #    - Second with 0.01 BTC fee (broadcasted to Bitcoin network)
-# 2. Submits the first transaction to Ethereum contract for deposit
+# 2. Submits the first transaction to uBTC contract for deposit
 # 3. Broadcasts the second transaction to Bitcoin network in same bitcoin block
 # 4. Mines confirmation blocks to ensure the double spend Bitcoin transaction is confirmed
 # 5. Check the balanceOf user and total supply slots in the sova uBTC smart contract
@@ -53,7 +53,7 @@ satoshi-suite mine-blocks --wallet-name "$WALLET_1" --blocks 1
 satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 100
 
 echo "Creating Bitcoin transactions..."
-# First transaction with 0.001 fee (this is the one we'll use for Ethereum)
+# First transaction with 0.001 fee
 TX1_OUTPUT=$(satoshi-suite sign-tx --wallet-name "$WALLET_1" --recipient "$UBTC_BITCOIN_RECEIVE_ADDRESS" --amount 49.999 --fee-amount 0.001)
 TX1_HEX=$(get_tx_hex "$TX1_OUTPUT")
 

--- a/scripts/dev-double-spend-test.sh
+++ b/scripts/dev-double-spend-test.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+# Resources:
+# https://github.com/PowVT/satoshi-suite
+# https://github.com/SovaNetwork/running-sova
+# https://github.com/foundry-rs
+
+# This script tests double-spend functionality for a dev sova-reth node using bitcoin regtest
+#
+# It:
+# 1. Creates two Bitcoin transactions spending the same UTXO:
+#    - First with 0.001 BTC fee (used for Ethereum deposit)
+#    - Second with 0.01 BTC fee (broadcasted to Bitcoin network)
+# 2. Submits the first transaction to Ethereum contract for deposit
+# 3. Broadcasts the second transaction to Bitcoin network in same bitcoin block
+# 4. Mines confirmation blocks to ensure the double spend Bitcoin transaction is confirmed
+# 5. Check the balanceOf user and total supply slots in the sova uBTC smart contract
+# 6. User user creates another Bitcoin transaction for a deposit of the same amount and sends to the node
+# 7. Check the balanceOf user and total supply slots again
+# 8. Confirm bitcoin transaction by mining bitcoin blocks
+# 9. Tests withdrawal functionality after the double-spend attack
+
+# Exit on error
+set -e
+
+# Configuration
+WALLET_1="user"
+WALLET_2="miner"
+UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q8pw3u88q56mfdqhxyeu0a7fesddq8jwsxxqng8"
+DOUBLE_SPEND_RECEIVE_ADDRESS="bcrt1q6xxa0arlrk6jdz02alxc6smdv5g953v7zkswaw" # random address for double spend
+ETH_RPC_URL="http://localhost:8545"
+ETH_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+CHAIN_ID="120893"
+
+# Function to convert BTC to smallest unit (satoshis)
+btc_to_sats() {
+    echo "$1 * 100000000" | bc | cut -d'.' -f1
+}
+
+# Function to extract transaction hex
+get_tx_hex() {
+    local output=$1
+    local hex=$(echo "$output" | grep "Signed transaction:" | sed 's/.*Signed transaction: //')
+    echo "$hex"
+}
+
+echo "Creating Bitcoin wallets..."
+satoshi-suite new-wallet --wallet-name "$WALLET_1"
+satoshi-suite new-wallet --wallet-name "$WALLET_2"
+
+echo "Mining initial blocks..."
+satoshi-suite mine-blocks --wallet-name "$WALLET_1" --blocks 1
+satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 100
+
+echo "Creating Bitcoin transactions..."
+# First transaction with 0.001 fee (this is the one we'll use for Ethereum)
+TX1_OUTPUT=$(satoshi-suite sign-tx --wallet-name "$WALLET_1" --recipient "$UBTC_BITCOIN_RECEIVE_ADDRESS" --amount 49.999 --fee-amount 0.001)
+TX1_HEX=$(get_tx_hex "$TX1_OUTPUT")
+
+# Second transaction with 0.01 fee
+TX2_OUTPUT=$(satoshi-suite sign-tx --wallet-name "$WALLET_1" --recipient "$DOUBLE_SPEND_RECEIVE_ADDRESS" --amount 49.99 --fee-amount 0.01)
+TX2_HEX=$(get_tx_hex "$TX2_OUTPUT")
+
+# For debugging
+echo "TX1 Hex: $TX1_HEX"
+echo "TX2 Hex: $TX2_HEX"
+
+echo "Deploying uBTC contract..."
+cd ~/contracts
+DEPLOY_OUTPUT=$(forge create --rpc-url http://localhost:8545 --broadcast \
+    --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+    src/uBTC.sol:uBTC)
+CONTRACT_ADDRESS=$(echo "$DEPLOY_OUTPUT" | grep "Deployed to:" | cut -d' ' -f3)
+echo "Contract deployed to: $CONTRACT_ADDRESS"
+
+cd ~
+
+# Convert 49.999 BTC to satoshis
+AMOUNT_SATS=$(btc_to_sats 49.999)
+
+echo "Submitting first transaction to Ethereum contract (0.001 fee)..."
+cast send \
+    --rpc-url "$ETH_RPC_URL" \
+    --private-key "$ETH_PRIVATE_KEY" \
+    --gas-limit 250000 \
+    --chain-id "$CHAIN_ID" \
+    "$CONTRACT_ADDRESS" \
+    "depositBTC(uint256,bytes)" \
+    "$AMOUNT_SATS" \
+    "0x$TX1_HEX"
+
+echo "Broadcasting competing Bitcoin transaction (0.01 fee)..."
+TX_BROADCAST_OUTPUT=$(satoshi-suite broadcast-tx --tx-hex "$TX2_HEX")
+TX_ID=$(echo "$TX_BROADCAST_OUTPUT" | grep "Broadcasted transaction:" | cut -d' ' -f3)
+
+echo "Mining confirmation blocks for double-spend transaction..."
+satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 19
+satoshi-suite mine-blocks --wallet-name "$WALLET_1" --blocks 1
+satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 100
+
+echo "Checking contract state..."
+    BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "balanceOf(address)" \
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+
+    TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "totalSupply()")
+
+    echo "Balance: $BALANCE"
+    echo "Total Supply: $TOTAL_SUPPLY"
+
+echo "Creating new Bitcoin transaction for second VALID deposit..."
+TX3_OUTPUT=$(satoshi-suite sign-tx --wallet-name "$WALLET_1" --recipient "$UBTC_BITCOIN_RECEIVE_ADDRESS" --amount 49.999 --fee-amount 0.001)
+TX3_HEX=$(get_tx_hex "$TX3_OUTPUT")
+
+echo "Submitting second deposit to Ethereum contract..."
+cast send \
+    --rpc-url "$ETH_RPC_URL" \
+    --private-key "$ETH_PRIVATE_KEY" \
+    --gas-limit 250000 \
+    --chain-id "$CHAIN_ID" \
+    "$CONTRACT_ADDRESS" \
+    "depositBTC(uint256,bytes)" \
+    "$AMOUNT_SATS" \
+    "0x$TX3_HEX"
+
+echo "Checking contract state..."
+    BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "balanceOf(address)" \
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+
+    TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+        "totalSupply()")
+
+    echo "Balance: $BALANCE"
+    echo "Total Supply: $TOTAL_SUPPLY"
+
+echo "Mining confirmation blocks for second deposit..."
+satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 7
+
+# Get current Bitcoin block height
+BLOCK_HEIGHT=$(satoshi-suite get-block-height | grep "Current block height:" | cut -d' ' -f8)
+
+# set withdrawal amount to 10.00 BTC
+WITHDRAWAL_AMOUNT=$(btc_to_sats 10.00)
+
+echo "Waiting for UTXO indexer to catch up..."
+while true; do
+    RESPONSE=$(curl -s "http://localhost:5557/latest-block")
+    LATEST_BLOCK=$(echo $RESPONSE | jq -r '.latest_block')
+    echo "Current BTC block height: $BLOCK_HEIGHT"
+    echo "Latest indexed block: $LATEST_BLOCK"
+    
+    if [ "$LATEST_BLOCK" -ge "$BLOCK_HEIGHT" ]; then
+        UTXOS=$(curl -s "http://localhost:5557/spendable-utxos/block/$BLOCK_HEIGHT/address/$UBTC_BITCOIN_RECEIVE_ADDRESS")
+        
+        # Check if we got an error response
+        if ! echo "$UTXOS" | jq -e '.error' > /dev/null; then
+            TOTAL_AMOUNT=$(echo "$UTXOS" | jq -r '.total_amount')
+            echo "Found UTXOs worth $TOTAL_AMOUNT satoshis"
+            if [ "$TOTAL_AMOUNT" -gt "$WITHDRAWAL_AMOUNT" ]; then
+                echo "Sufficient UTXOs found for withdrawal of $WITHDRAWAL_AMOUNT satoshis"
+                break
+            fi
+        else
+            echo "Waiting for UTXOs to be indexed..."
+        fi
+    fi
+    sleep 2
+done
+
+# echo "Initiating withdrawal..."
+# sleep 5
+
+# # Generate new Bitcoin address for withdrawal
+# NEW_ADDRESS=$(satoshi-suite get-new-address --wallet-name "$WALLET_1" | grep "New address:" | cut -d' ' -f3)
+
+# cast send \
+#     --rpc-url "$ETH_RPC_URL" \
+#     --private-key "$ETH_PRIVATE_KEY" \
+#     --gas-limit 300000 \
+#     --chain-id "$CHAIN_ID" \
+#     "$CONTRACT_ADDRESS" \
+#     "withdraw(uint64,uint32,string)" \
+#     "$WITHDRAWAL_AMOUNT" \
+#     "120" \
+#     "$NEW_ADDRESS"
+
+# echo "Checking contract state..."
+#     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+#         "balanceOf(address)" \
+#         "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+
+#     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
+#         "totalSupply()")
+
+#     echo "Balance: $BALANCE"
+#     echo "Total Supply: $TOTAL_SUPPLY"
+
+echo "Done!"


### PR DESCRIPTION
Deterministic unlocking for the sentinel 'lock state' machine.

Slot reverts are uncovered in a execution dry run phase of the PayloadBuilder and ExecutorBuilder flows prior to actual state execution. After the dry run, revert state changes provided by the sentinel are applied to the state database. This way during the actual execution of the transactions in the block they are run on top of the applied slot reverts.

The process of applying the slot reverts we are calling database "masking". Since our double spend protection system uses Bitcoin block confirmations as a signal to update the state of our locked slots we are applying this signal in the form of a mask to the node's database.

After masking the database and execution of transactions. The updating of sentinel state occurs after the block has been built internally by the ExecutorBuilder, this way payload building and block execution can use the same sentinel 'state' and fulfill their deterministic state machine requirements.