### PR TITLE
rm broadcast queue logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ CMD ["sova-reth node \
     --btc-rpc-password $BTC_RPC_PASSWORD \
     --network-signing-url $NETWORK_SIGNING_URL \
     --network-utxo-url $NETWORK_UTXO_URL \
-    --btc-tx-queue-url $BTC_TX_QUEUE_URL \
     --sentinel-url $SENTINEL_URL \
     --chain $CHAIN \
     --datadir /var/lib/sova \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The new precompile is found at address 0x999 and accepts a bytes payload of data
 
 | Precompile Name | Address | Method Identifier (bytes) | Gas Cost | Gas Limit | Description |
 |-----------------|-----|---------------------------|----------|-----------|-------------|
-| sendrawtransaction | 0x999 | 0x00000001 | 6,000 + 3 * input.len() | 450,000 | Broadcast a raw Bitcoin transaction. |
+| sendrawtransaction | 0x999 | 0x00000001 | 21,000 | 450,000 | Broadcast a raw Bitcoin transaction. |
 | decoderawtransaction | 0x999 | 0x00000002 | 2,000 + 3 * input.len() | 150,000 | Decode a raw Bitcoin transaction. |
 | verifysignature | 0x999 | 0x00000003 | 4,000 + 3 * input.len() | 300,000 | Verifies the unlocking scripts in a signed transaction are able to spend the specified inputs. |
 | convertaddress | 0x999 |  0x00000004 | 3,000 | N/A | Converts a Sova address to the corresponding BTC address using the network master key. |

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -46,7 +46,6 @@ pub struct SovaConfig {
     pub bitcoin_config: Arc<BitcoinConfig>,
     pub network_signing_url: String,
     pub network_utxo_url: String,
-    pub btc_tx_queue_url: String,
     pub sentinel_url: String,
 }
 
@@ -55,14 +54,12 @@ impl SovaConfig {
         bitcoin_config: BitcoinConfig,
         network_signing_url: &str,
         network_utxo_url: &str,
-        btc_tx_queue_url: &str,
         sentinel_url: &str,
     ) -> Self {
         SovaConfig {
             bitcoin_config: Arc::new(bitcoin_config),
             network_signing_url: network_signing_url.to_owned(),
             network_utxo_url: network_utxo_url.to_owned(),
-            btc_tx_queue_url: btc_tx_queue_url.to_owned(),
             sentinel_url: sentinel_url.to_owned(),
         }
     }
@@ -74,7 +71,6 @@ impl Default for SovaConfig {
             bitcoin_config: Arc::new(BitcoinConfig::default()),
             network_signing_url: String::new(),
             network_utxo_url: String::new(),
-            btc_tx_queue_url: String::new(),
             sentinel_url: String::new(),
         }
     }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -55,7 +55,6 @@ impl MyEvmConfig {
             config.bitcoin_config.network,
             config.network_signing_url.clone(),
             config.network_utxo_url.clone(),
-            config.btc_tx_queue_url.clone(),
         )?;
 
         let inspector = SovaInspector::new(

--- a/crates/evm/src/precompiles/btc_client.rs
+++ b/crates/evm/src/precompiles/btc_client.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use bitcoin::{BlockHash, Transaction, Txid};
-use bitcoincore_rpc::{json::DecodeRawTransactionResult, Auth, Client, RpcApi};
+use bitcoin::{BlockHash, Transaction};
+use bitcoincore_rpc::{bitcoin::Txid, json::DecodeRawTransactionResult, Auth, Client, RpcApi};
 
 use sova_cli::BitcoinConfig;
 
@@ -63,5 +63,9 @@ impl BitcoinClient {
 
     pub fn get_block_height(&self) -> Result<u64, bitcoincore_rpc::Error> {
         self.client.get_block_count()
+    }
+
+    pub fn send_raw_transaction(&self, tx: &Transaction) -> Result<Txid, bitcoincore_rpc::Error> {
+        self.client.send_raw_transaction(tx)
     }
 }

--- a/crates/evm/src/precompiles/mod.rs
+++ b/crates/evm/src/precompiles/mod.rs
@@ -140,12 +140,8 @@ impl BitcoinRpcPrecompile {
         )
     }
 
-    fn send_btc_tx(&self, input: &[u8], gas_limit: u64) -> PrecompileResult {
+    fn send_btc_tx(&self, input: &[u8]) -> PrecompileResult {
         let gas_used: u64 = 21_000_u64;
-
-        if gas_used > gas_limit {
-            return Err(PrecompileErrors::Error(PrecompileError::OutOfGas));
-        }
 
         // Deserialize the Bitcoin transaction
         let tx: bitcoin::Transaction = match deserialize(input) {
@@ -478,7 +474,7 @@ impl StatefulPrecompile for BitcoinRpcPrecompile {
         let input_data = &input[4..];
 
         match method {
-            BitcoinMethod::BroadcastTransaction => self.send_btc_tx(input_data, method.gas_limit()),
+            BitcoinMethod::BroadcastTransaction => self.send_btc_tx(input_data),
             BitcoinMethod::DecodeTransaction => {
                 self.decode_raw_transaction(input_data, method.gas_limit())
             }

--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -29,10 +29,6 @@ pub struct SovaArgs {
     #[arg(long, default_value = "http://127.0.0.1:5557")]
     pub network_utxo_url: String,
 
-    /// CLI flag to indicate the bitcoin transaction queue url
-    #[arg(long, default_value = "http://127.0.0.1:5558")]
-    pub btc_tx_queue_url: String,
-
     /// CLI flag to indicate the storage slot provider url
     #[arg(long, default_value = "http://[::1]:50051")]
     pub sentinel_url: String,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -54,7 +54,6 @@ impl SovaNode {
             btc_config,
             &args.network_signing_url,
             &args.network_utxo_url,
-            &args.btc_tx_queue_url,
             &args.sentinel_url,
         );
 

--- a/justfile
+++ b/justfile
@@ -27,7 +27,6 @@ run-sova-regtest clean="false":
     --btc-rpc-password "password" \
     --network-signing-url "http://127.0.0.1:5555" \
     --network-utxo-url "http://127.0.0.1:5557" \
-    --btc-tx-queue-url "http://127.0.0.1:5558" \
     --sentinel-url "http://[::1]:50051" \
     --http \
     --http.addr "127.0.0.1" \
@@ -53,7 +52,6 @@ run-sova-mainnet-regtest clean="false":
     --btc-rpc-password "password" \
     --network-signing-url "http://127.0.0.1:5555" \
     --network-utxo-url "http://127.0.0.1:5557" \
-    --btc-tx-queue-url "http://127.0.0.1:5558" \
     --sentinel-url "http://[::1]:50051" \
     --addr "0.0.0.0" \
     --port 30303 \


### PR DESCRIPTION
Remove all connections to the `btc_tx_queue` and replace with direct `sendrawtransaction` requests to the Bitcoin node.

Ignore specific BTC client errors when broadcasting a BTC tx to make all future broadcasts of the same tx idempotent. This characteristic is important for when nodes are syncing or re-executing blocks.