### PR TITLE
update sentinel locks in payload building flow

### DIFF
--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -310,11 +310,15 @@ where
             let inspector_lock = self.evm_config.with_inspector();
             let mut inspector = inspector_lock.write();
 
-            // handle unlocking of reverted slot cache via slot lock provider
-            // and locking of storage slots for any btc broadcasts in this block
+            // handle locking of storage slots for any btc broadcasts in this block
             inspector
                 .update_sentinel_locks(block.number())
-                .map_err(|err| InternalBlockExecutionError::Other(Box::new(err)))?;
+                .map_err(|err| {
+                    InternalBlockExecutionError::msg(format!(
+                        "Failed to update sentinel locks: {}",
+                        err
+                    ))
+                })?;
         }
 
         Ok(requests)

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -318,7 +318,7 @@ where
                 .update_sentinel_locks(locked_block_num)
                 .map_err(|err| {
                     InternalBlockExecutionError::msg(format!(
-                        "Failed to update sentinel locks: {}",
+                        "Execution error: Failed to update sentinel locks: {}",
                         err
                     ))
                 })?;

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -310,9 +310,12 @@ where
             let inspector_lock = self.evm_config.with_inspector();
             let mut inspector = inspector_lock.write();
 
+            // locks are to be applied to the next block
+            let locked_block_num: u64 = block.number() + 1;
+
             // handle locking of storage slots for any btc broadcasts in this block
             inspector
-                .update_sentinel_locks(block.number())
+                .update_sentinel_locks(locked_block_num)
                 .map_err(|err| {
                     InternalBlockExecutionError::msg(format!(
                         "Failed to update sentinel locks: {}",

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -499,13 +499,19 @@ where
     // Release db
     drop(evm);
 
+    // Release inspector
+    drop(inspector);
+
     {
         let inspector_lock = evm_config.with_inspector();
         let mut inspector = inspector_lock.write();
 
+        // locks are to be applied to the next block
+        let locked_block_num: u64 = block_number + 1;
+
         // handle locking of storage slots for any btc broadcasts in this block
         inspector
-            .update_sentinel_locks(block_number)
+            .update_sentinel_locks(locked_block_num)
             .map_err(|err| {
                 PayloadBuilderError::Internal(RethError::msg(format!(
                     "WARNING: Payload building error: Failed to update sentinel locks: {}",

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -499,6 +499,21 @@ where
     // Release db
     drop(evm);
 
+    {
+        let inspector_lock = evm_config.with_inspector();
+        let mut inspector = inspector_lock.write();
+
+        // handle locking of storage slots for any btc broadcasts in this block
+        inspector
+            .update_sentinel_locks(block_number)
+            .map_err(|err| {
+                PayloadBuilderError::Internal(RethError::msg(format!(
+                    "WARNING: Payload building error: Failed to update sentinel locks: {}",
+                    err
+                )))
+            })?;
+    }
+
     let withdrawals_root = commit_withdrawals(
         &mut db,
         &chain_spec,

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -514,7 +514,7 @@ where
             .update_sentinel_locks(locked_block_num)
             .map_err(|err| {
                 PayloadBuilderError::Internal(RethError::msg(format!(
-                    "WARNING: Payload building error: Failed to update sentinel locks: {}",
+                    "Payload building error: Failed to update sentinel locks: {}",
                     err
                 )))
             })?;

--- a/scripts/dev-double-spend-test-withdraw.sh
+++ b/scripts/dev-double-spend-test-withdraw.sh
@@ -26,12 +26,12 @@ set -e
 # Configuration
 WALLET_1="user"
 WALLET_2="miner"
-UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q7c3qwje2ku5ej38s38srftxaqt6zh0szl5qstz" # needs to be updated when eth_address changes since the ETH_ADDRESS is deployer
+UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q8pw3u88q56mfdqhxyeu0a7fesddq8jwsxxqng8" # needs to be updated when eth_address changes since the ETH_ADDRESS is deployer
 DOUBLE_SPEND_RECEIVE_ADDRESS="bcrt1q6xxa0arlrk6jdz02alxc6smdv5g953v7zkswaw" # random address for double spend
-ETH_RPC_URL="http://localhost:54732"
-ETH_ADDRESS="0x8943545177806ED17B9F23F0a21ee5948eCaa776"
-ETH_PRIVATE_KEY="0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
-CHAIN_ID="3151908"
+ETH_RPC_URL="http://localhost:8545"
+ETH_ADDRESS="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+ETH_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+CHAIN_ID="120893"
 
 # Function to convert BTC to smallest unit (satoshis)
 btc_to_sats() {

--- a/scripts/dev-double-spend-test-withdraw.sh
+++ b/scripts/dev-double-spend-test-withdraw.sh
@@ -26,11 +26,12 @@ set -e
 # Configuration
 WALLET_1="user"
 WALLET_2="miner"
-UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q8pw3u88q56mfdqhxyeu0a7fesddq8jwsxxqng8"
+UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q7c3qwje2ku5ej38s38srftxaqt6zh0szl5qstz" # needs to be updated when eth_address changes since the ETH_ADDRESS is deployer
 DOUBLE_SPEND_RECEIVE_ADDRESS="bcrt1q6xxa0arlrk6jdz02alxc6smdv5g953v7zkswaw" # random address for double spend
-ETH_RPC_URL="http://localhost:8545"
-ETH_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-CHAIN_ID="120893"
+ETH_RPC_URL="http://localhost:54732"
+ETH_ADDRESS="0x8943545177806ED17B9F23F0a21ee5948eCaa776"
+ETH_PRIVATE_KEY="0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
+CHAIN_ID="3151908"
 
 # Function to convert BTC to smallest unit (satoshis)
 btc_to_sats() {
@@ -101,7 +102,7 @@ satoshi-suite mine-blocks --wallet-name "$WALLET_2" --blocks 100
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
+        "$ETH_ADDRESS" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "totalSupply()" | cast to-dec)
 
@@ -126,7 +127,7 @@ cast send \
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
+        "$ETH_ADDRESS" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "totalSupply()" | cast to-dec)
 
@@ -186,7 +187,7 @@ cast send \
 echo "Checking contract state..."
     BALANCE=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "balanceOf(address)" \
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" | cast to-dec)
+        "$ETH_ADDRESS" | cast to-dec)
     TOTAL_SUPPLY=$(cast call --rpc-url "$ETH_RPC_URL" "$CONTRACT_ADDRESS" \
         "totalSupply()" | cast to-dec)
 


### PR DESCRIPTION
Previously sentinel locks were only updated in the execution flow. This works in a single node env because after payload building the consensus layer is "mocked" so the single node also passes the block through the execution flow which updates the locks.

In a multi-node env, when the consensus layer asks the engine to build a payload, it will not go through the execution flow, it will only go through the consensus flow and consequently none of the slot locks will be updated. This is a problem because other nodes in the network will build the block differently as they will build it via the execution flow and locks will be updated properly.