### PR TITLE
bump sentinel to 84cb0d1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "sova-sentinel-client"
 version = "0.1.0"
-source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=058b383887518ec5c2a973e006b53b7d0585ca01#058b383887518ec5c2a973e006b53b7d0585ca01"
+source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=84cb0d1371a7ce8a06cc5cc61c09cc2178a27d1e#84cb0d1371a7ce8a06cc5cc61c09cc2178a27d1e"
 dependencies = [
  "prost",
  "sova-sentinel-proto",
@@ -8831,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "sova-sentinel-proto"
 version = "0.1.0"
-source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=058b383887518ec5c2a973e006b53b7d0585ca01#058b383887518ec5c2a973e006b53b7d0585ca01"
+source = "git+https://github.com/SovaNetwork/sova-sentinel.git?rev=84cb0d1371a7ce8a06cc5cc61c09cc2178a27d1e#84cb0d1371a7ce8a06cc5cc61c09cc2178a27d1e"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ sova-node = { path = "crates/node" }
 sova-payload = { path = "crates/payload" }
 
 # sova external
-sova-sentinel-client = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "058b383887518ec5c2a973e006b53b7d0585ca01" }
-sova-sentinel-proto = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "058b383887518ec5c2a973e006b53b7d0585ca01" }
+sova-sentinel-client = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "84cb0d1371a7ce8a06cc5cc61c09cc2178a27d1e" }
+sova-sentinel-proto = { git = "https://github.com/SovaNetwork/sova-sentinel.git", rev = "84cb0d1371a7ce8a06cc5cc61c09cc2178a27d1e" }
 
 # reth
 reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "6c3b1b8bcd7f86e115ab4703719056dc8998a00e" }


### PR DESCRIPTION
The client as been updated to use locked_at_block instead of locked_block. The param index hasn't changed so there is no implementation change in reth. I am just bumping this to stay in sync with sentinel.