### PR TITLE
fix: sentinel unknown response revert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ run-sova-regtest: ## Compile and run sova-reth in dev mode using bitcoin regtest
 	--network-utxo-url "http://127.0.0.1:5557" \
 	--sentinel-url "http://[::1]:50051" \
 	--sentinel-confirmation-threshold 6 \
-	--sequencer-mode true \
+	--sequencer-mode \
 	--http \
 	--http.addr "127.0.0.1" \
 	--http.port 8545 \

--- a/crates/sova-evm/src/inspector/mod.rs
+++ b/crates/sova-evm/src/inspector/mod.rs
@@ -273,10 +273,10 @@ impl SovaInspector {
                         Status::Unknown => {
                             warn!("WARNING: Status::Unknown returned from sentinel. Check sentinel's BTC rpc copnnection");
                             return Some(Self::create_revert_outcome(
-                                format!("Unknown returned from sentinel. Check sentinel's BTC rpc copnnection"),
+                                "Unknown returned from sentinel. Check sentinel's BTC rpc copnnection".to_string(),
                                 inputs.gas_limit,
                                 inputs.return_memory_offset.clone(),
-                            ))
+                            ));
                         }
                         Status::Locked => {
                             debug!("Storage slot is locked");

--- a/crates/sova-evm/src/inspector/mod.rs
+++ b/crates/sova-evm/src/inspector/mod.rs
@@ -308,11 +308,14 @@ impl SovaInspector {
                 }
                 None
             }
-            Err(err) => Some(Self::create_revert_outcome(
-                format!("Failed to get lock status from provider: {}", err),
-                inputs.gas_limit,
-                inputs.return_memory_offset.clone(),
-            )),
+            Err(err) => {
+                warn!("WARNING: Failed to get lock status from sentinel, check connection to sentinel");
+                Some(Self::create_revert_outcome(
+                    format!("Failed to get lock status from sentinel: {}", err),
+                    inputs.gas_limit,
+                    inputs.return_memory_offset.clone(),
+                ))
+            }
         }
     }
 

--- a/crates/sova-evm/src/inspector/mod.rs
+++ b/crates/sova-evm/src/inspector/mod.rs
@@ -271,7 +271,12 @@ impl SovaInspector {
 
                     match status {
                         Status::Unknown => {
-                            warn!("WARNING: Status::Unknown returned from sentinel");
+                            warn!("WARNING: Status::Unknown returned from sentinel. Check sentinel's BTC rpc copnnection");
+                            return Some(Self::create_revert_outcome(
+                                format!("Unknown returned from sentinel. Check sentinel's BTC rpc copnnection"),
+                                inputs.gas_limit,
+                                inputs.return_memory_offset.clone(),
+                            ))
                         }
                         Status::Locked => {
                             debug!("Storage slot is locked");

--- a/crates/sova-evm/src/precompiles/mod.rs
+++ b/crates/sova-evm/src/precompiles/mod.rs
@@ -155,6 +155,7 @@ impl BitcoinRpcPrecompile {
             .send()
             .map_err(|e| PrecompileError::Other(format!("HTTP request failed: {}", e)))?
             .json()
+            // TODO(powvt): check for error responses from enclave
             .map_err(|e| PrecompileError::Other(format!("Failed to parse response: {}", e)))
     }
 
@@ -384,7 +385,7 @@ impl BitcoinRpcPrecompile {
         ethereum_address_trimmed: &str,
     ) -> Result<String, PrecompileError> {
         let enclave_request = serde_json::json!({
-            "ethereum_address": ethereum_address_trimmed
+            "evm_address": ethereum_address_trimmed
         });
 
         let response: serde_json::Value = self.call_enclave("derive_address", &enclave_request)?;
@@ -463,7 +464,7 @@ impl BitcoinRpcPrecompile {
             // === Sign Using Signers PK ===
 
             let sign_request = serde_json::json!({
-                "ethereum_address": decoded_input.signer,
+                "evm_address": decoded_input.signer,
                 "inputs": inputs,
                 "outputs": outputs,
             });

--- a/scripts/dev-double-spend-test-transfer.sh
+++ b/scripts/dev-double-spend-test-transfer.sh
@@ -19,7 +19,7 @@ set -e
 # Configuration
 WALLET_1="user"
 WALLET_2="miner"
-UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q8pw3u88q56mfdqhxyeu0a7fesddq8jwsxxqng8" # needs to be updated when eth_address changes since the ETH_ADDRESS is deployer
+UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q5443nh36k845xcecc53wttj4gpkg5jguvr4rev" # needs to be updated when eth_address changes since the ETH_ADDRESS is deployer
 ETH_RPC_URL="http://localhost:8545"
 ETH_ADDRESS="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 ETH_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"

--- a/scripts/dev-double-spend-test-withdraw.sh
+++ b/scripts/dev-double-spend-test-withdraw.sh
@@ -26,7 +26,7 @@ set -e
 # Configuration
 WALLET_1="user"
 WALLET_2="miner"
-UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q8pw3u88q56mfdqhxyeu0a7fesddq8jwsxxqng8" # needs to be updated when eth_address changes since the ETH_ADDRESS is deployer
+UBTC_BITCOIN_RECEIVE_ADDRESS="bcrt1q5443nh36k845xcecc53wttj4gpkg5jguvr4rev" # needs to be updated when eth_address changes since the ETH_ADDRESS is deployer
 DOUBLE_SPEND_RECEIVE_ADDRESS="bcrt1q6xxa0arlrk6jdz02alxc6smdv5g953v7zkswaw" # random address for double spend
 ETH_RPC_URL="http://localhost:8545"
 ETH_ADDRESS="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"


### PR DESCRIPTION
UNKNOWN responses from the sentinel indicates that the BTC client connection failed from the sentinel.

Similar to erroring when the sentinel client connection fails, this falls under the same logic.