### PR TITLE
Follow OP Chain specification

### DIFF
--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -2,8 +2,12 @@ use clap::Parser;
 
 use bitcoin::Network;
 
-/// Our custom cli args extension that adds flags to configure the bitcoin rpc client
-#[derive(Clone, Debug, Default, Parser)]
+use op_alloy_consensus::interop::SafetyLevel;
+
+use reth_optimism_txpool::supervisor::DEFAULT_SUPERVISOR_URL;
+
+/// Custom cli args extension that adds flags to configure Bitcoin functionality
+#[derive(Clone, Debug, Parser)]
 pub struct SovaArgs {
     /// CLI flag to indicate the bitcoin network the bitcoin rpc client will connect to
     #[arg(long, value_parser = parse_network_to_wrapper, default_value = "regtest")]
@@ -42,13 +46,80 @@ pub struct SovaArgs {
     #[arg(long, default_value = "6")]
     pub sentinel_confirmation_threshold: u8,
 
+    /// enable sequencer mode, this is for validators who are able to process network signed transactions
+    #[arg(long, default_value = "false")]
+    pub sequencer_mode: bool,
+
+    /// Endpoint for the sequencer mempool (can be both HTTP and WS)
+    #[arg(long = "rollup.sequencer", visible_aliases = ["rollup.sequencer-http", "rollup.sequencer-ws"])]
+    pub sequencer: Option<String>,
+
+    /// Disable transaction pool gossip
+    #[arg(long = "rollup.disable-tx-pool-gossip")]
+    pub disable_txpool_gossip: bool,
+
+    /// Enable walkback to genesis on startup. This is useful for re-validating the existing DB
+    /// prior to beginning normal syncing.
+    #[arg(long = "rollup.enable-genesis-walkback")]
+    pub enable_genesis_walkback: bool,
+
+    /// By default the pending block equals the latest block
+    /// to save resources and not leak txs from the tx-pool,
+    /// this flag enables computing of the pending block
+    /// from the tx-pool instead.
+    ///
+    /// If `compute_pending_block` is not enabled, the payload builder
+    /// will use the payload attributes from the latest block. Note
+    /// that this flag is not yet functional.
+    #[arg(long = "rollup.compute-pending-block")]
+    pub compute_pending_block: bool,
+
+    /// enables discovery v4 if provided
+    #[arg(long = "rollup.discovery.v4", default_value = "false")]
+    pub discovery_v4: bool,
+
     /// Enable transaction conditional support on sequencer
     #[arg(long = "rollup.enable-tx-conditional", default_value = "false")]
     pub enable_tx_conditional: bool,
 
-    /// enable sequencer mode, this is for validators who are able to process network signed transactions
-    #[arg(long, default_value = "false")]
-    pub sequencer_mode: bool,
+    /// HTTP endpoint for the supervisor
+    #[arg(
+        long = "rollup.supervisor-http",
+        value_name = "SUPERVISOR_HTTP_URL",
+        default_value = DEFAULT_SUPERVISOR_URL
+    )]
+    pub supervisor_http: String,
+
+    /// Safety level for the supervisor
+    #[arg(
+        long = "rollup.supervisor-safety-level",
+        default_value_t = SafetyLevel::CrossUnsafe,
+    )]
+    pub supervisor_safety_level: SafetyLevel,
+}
+
+impl Default for SovaArgs {
+    fn default() -> Self {
+        Self {
+            btc_network: BitcoinNetwork::default(),
+            network_url: "http://127.0.0.1".to_string(),
+            btc_rpc_username: "user".to_string(),
+            btc_rpc_password: "password".to_string(),
+            network_signing_url: "http://127.0.0.1:5555".to_string(),
+            network_utxo_url: "http://127.0.0.1:5557".to_string(),
+            sentinel_url: "http://[::1]:50051".to_string(),
+            sentinel_confirmation_threshold: 6,
+            sequencer_mode: false,
+            sequencer: None,
+            disable_txpool_gossip: false,
+            enable_genesis_walkback: false,
+            compute_pending_block: false,
+            discovery_v4: false,
+            enable_tx_conditional: false,
+            supervisor_http: DEFAULT_SUPERVISOR_URL.to_string(),
+            supervisor_safety_level: SafetyLevel::CrossUnsafe,
+        }
+    }
 }
 
 fn parse_network_to_wrapper(s: &str) -> Result<BitcoinNetwork, &'static str> {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use reth_ethereum_consensus::EthBeaconConsensus;
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor};
 use reth_node_api::{
-    AddOnsContext, FullNodeComponents, NodeAddOns, NodePrimitives, NodeTypes, PrimitivesTy, TxTy
+    AddOnsContext, FullNodeComponents, NodeAddOns, NodePrimitives, NodeTypes, PrimitivesTy, TxTy,
 };
 use reth_node_builder::{
     components::{
@@ -24,7 +24,10 @@ use reth_optimism_node::{
     txpool::OpPooledTx,
     OpEngineTypes, OpNextBlockEnvAttributes,
 };
-use reth_optimism_payload_builder::{builder::OpPayloadTransactions, config::{OpBuilderConfig, OpDAConfig}};
+use reth_optimism_payload_builder::{
+    builder::OpPayloadTransactions,
+    config::{OpBuilderConfig, OpDAConfig},
+};
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives, OpTransactionSigned};
 use reth_optimism_rpc::OpEthApiError;
 
@@ -417,7 +420,9 @@ impl<Txs> SovaPayloadBuilder<Txs> {
             pool,
             ctx.provider().clone(),
             evm_config,
-            OpBuilderConfig { da_config: self.da_config.clone() },
+            OpBuilderConfig {
+                da_config: self.da_config.clone(),
+            },
         )
         .with_sova_integration(self.config.clone(), self.bitcoin_client.clone())
         .with_transactions(self.best_transactions.clone())

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use reth_ethereum_consensus::EthBeaconConsensus;
-use reth_ethereum_payload_builder::EthereumBuilderConfig;
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, NodeAddOns, NodePrimitives, NodeTypes, PrimitivesTy, TxTy
@@ -16,7 +15,7 @@ use reth_node_builder::{
         EngineValidatorAddOn, EngineValidatorBuilder, EthApiBuilder, RethRpcAddOns, RpcAddOns,
         RpcHandle,
     },
-    BuilderContext, Node, NodeAdapter, NodeComponentsBuilder, PayloadBuilderConfig,
+    BuilderContext, Node, NodeAdapter, NodeComponentsBuilder,
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
@@ -414,13 +413,13 @@ impl<Txs> SovaPayloadBuilder<Txs> {
         Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>>,
         Txs: OpPayloadTransactions<Pool::Transaction>,
     {
-        let payload_builder = sova_payload::SovaPayloadBuilder::new(
-            ctx.provider().clone(),
+        let payload_builder = sova_payload::SovaPayloadBuilder::with_builder_config(
             pool,
+            ctx.provider().clone(),
             evm_config,
             OpBuilderConfig { da_config: self.da_config.clone() },
-            self.bitcoin_client.clone(),
         )
+        .with_sova_integration(self.config.clone(), self.bitcoin_client.clone())
         .with_transactions(self.best_transactions.clone())
         .set_compute_pending_block(self.compute_pending_block);
         Ok(payload_builder)

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -470,8 +470,8 @@ where
 
 /// A type that knows how to build the Sova EVM.
 ///
-/// The Sova EVM is customized such that there are new precompiles and a
-/// custom inspector which is used for enforcing transaction finality on Bitcoin.
+/// The Sova EVM is customized such that there are Bitcoin precompiles as well as
+/// a custom inspector which is used for enforcing transaction finality on Bitcoin.
 #[derive(Debug, Default, Clone)]
 pub struct SovaExecutorBuilder {
     pub config: SovaConfig,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,13 +1,10 @@
 use std::sync::Arc;
 
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor};
-use reth_node_api::{
-    AddOnsContext, FullNodeComponents, NodeAddOns, NodeTypes, PrimitivesTy, TxTy,
-};
+use reth_node_api::{AddOnsContext, FullNodeComponents, NodeAddOns, NodeTypes, PrimitivesTy, TxTy};
 use reth_node_builder::{
     components::{
-        BasicPayloadServiceBuilder, ComponentsBuilder, ExecutorBuilder,
-        PayloadBuilderBuilder,
+        BasicPayloadServiceBuilder, ComponentsBuilder, ExecutorBuilder, PayloadBuilderBuilder,
     },
     node::FullNodeTypes,
     rpc::{

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,17 +1,15 @@
 use std::sync::Arc;
 
-use op_alloy_consensus::{interop::SafetyLevel, OpPooledTransaction};
 use reth_ethereum_consensus::EthBeaconConsensus;
 use reth_ethereum_payload_builder::EthereumBuilderConfig;
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor};
-use reth_network::{NetworkHandle, PeersInfo};
 use reth_node_api::{
-    AddOnsContext, FullNodeComponents, NodeAddOns, NodePrimitives, NodeTypes, TxTy,
+    AddOnsContext, FullNodeComponents, NodeAddOns, NodePrimitives, NodeTypes, PrimitivesTy, TxTy
 };
 use reth_node_builder::{
     components::{
         BasicPayloadServiceBuilder, ComponentsBuilder, ConsensusBuilder, ExecutorBuilder,
-        NetworkBuilder, PayloadBuilderBuilder, PoolBuilder, PoolBuilderConfigOverrides,
+        PayloadBuilderBuilder,
     },
     node::FullNodeTypes,
     rpc::{
@@ -23,31 +21,23 @@ use reth_node_builder::{
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{
-    txpool::{
-        conditional::MaybeConditionalTransaction, interop::MaybeInteropTransaction,
-        supervisor::DEFAULT_SUPERVISOR_URL, OpPooledTx,
-    },
-    OpEngineTypes, OpNetworkPrimitives, OpNextBlockEnvAttributes,
+    node::{OpNetworkBuilder, OpPoolBuilder},
+    txpool::OpPooledTx,
+    OpEngineTypes, OpNextBlockEnvAttributes,
 };
-use reth_optimism_payload_builder::builder::OpPayloadTransactions;
+use reth_optimism_payload_builder::{builder::OpPayloadTransactions, config::{OpBuilderConfig, OpDAConfig}};
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives, OpTransactionSigned};
 use reth_optimism_rpc::OpEthApiError;
-use reth_optimism_txpool::supervisor::SupervisorClient;
-use reth_provider::CanonStateSubscriptions;
+
 use reth_provider::{providers::ProviderFactoryBuilder, EthStorage};
 use reth_rpc_eth_types::error::FromEvmError;
-use reth_tracing::tracing::{debug, info};
-use reth_transaction_pool::{
-    blobstore::DiskFileBlobStore, CoinbaseTipOrdering, EthPoolTransaction, PoolTransaction,
-    TransactionPool, TransactionValidationTaskExecutor,
-};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use reth_trie_db::MerklePatriciaTrie;
 
 use revm_context::TxEnv;
 use sova_cli::{BitcoinConfig, SovaConfig};
 use sova_evm::{BitcoinClient, MyEvmConfig, SovaBlockExecutorProvider};
 use sova_rpc::{SovaEthApi, SovaEthApiBuilder};
-use sova_txpool::{SovaTransactionPool, SovaTransactionValidator};
 
 use crate::{engine::SovaEngineValidator, rpc::SovaEngineApiBuilder, SovaArgs};
 
@@ -58,12 +48,19 @@ pub type SovaStorage = EthStorage<OpTransactionSigned>;
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct SovaNode {
-    /// Additional Sova args
+    /// Additional Sova args with Op Rollup Args
     pub args: SovaArgs,
     /// Bitcoin client wrapper
     pub bitcoin_client: Arc<BitcoinClient>,
     /// Node configuration
     pub sova_config: SovaConfig,
+    /// Data availability configuration for the OP builder.
+    ///
+    /// Used to throttle the size of the data availability payloads (configured by the batcher via
+    /// the `miner_` api).
+    ///
+    /// By default no throttling is applied.
+    pub da_config: OpDAConfig,
 }
 
 impl SovaNode {
@@ -94,7 +91,14 @@ impl SovaNode {
             args,
             bitcoin_client: Arc::new(bitcoin_client),
             sova_config,
+            da_config: OpDAConfig::default(),
         })
+    }
+
+    /// Configure the data availability configuration for the builder.
+    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+        self.da_config = da_config;
+        self
     }
 
     /// Returns the components for the given [`SovaArgs`].
@@ -102,9 +106,9 @@ impl SovaNode {
         &self,
     ) -> ComponentsBuilder<
         Node,
-        SovaPoolBuilder,
+        OpPoolBuilder,
         BasicPayloadServiceBuilder<SovaPayloadBuilder>,
-        SovaNetworkBuilder,
+        OpNetworkBuilder,
         SovaExecutorBuilder,
         SovaConsensusBuilder,
     >
@@ -118,17 +122,35 @@ impl SovaNode {
             >,
         >,
     {
-        let pool_builder =
-            SovaPoolBuilder::default().with_enable_tx_conditional(self.args.enable_tx_conditional);
+        let SovaArgs {
+            disable_txpool_gossip,
+            compute_pending_block,
+            discovery_v4,
+            ..
+        } = self.args;
 
         ComponentsBuilder::default()
             .node_types::<Node>()
-            .pool(pool_builder)
-            .payload(BasicPayloadServiceBuilder::new(SovaPayloadBuilder::new(
-                self.sova_config.clone(),
-                Arc::clone(&self.bitcoin_client),
-            )))
-            .network(SovaNetworkBuilder)
+            .pool(
+                OpPoolBuilder::default()
+                    .with_enable_tx_conditional(self.args.enable_tx_conditional)
+                    .with_supervisor(
+                        self.args.supervisor_http.clone(),
+                        self.args.supervisor_safety_level,
+                    ),
+            )
+            .payload(BasicPayloadServiceBuilder::new(
+                SovaPayloadBuilder::new(
+                    self.sova_config.clone(),
+                    Arc::clone(&self.bitcoin_client),
+                    compute_pending_block,
+                )
+                .with_da_config(self.da_config.clone()),
+            ))
+            .network(OpNetworkBuilder {
+                disable_txpool_gossip,
+                disable_discovery_v4: !discovery_v4,
+            })
             .executor(SovaExecutorBuilder::new(
                 self.sova_config.clone(),
                 Arc::clone(&self.bitcoin_client),
@@ -154,9 +176,9 @@ where
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
-        SovaPoolBuilder,
+        OpPoolBuilder,
         BasicPayloadServiceBuilder<SovaPayloadBuilder>,
-        SovaNetworkBuilder,
+        OpNetworkBuilder,
         SovaExecutorBuilder,
         SovaConsensusBuilder,
     >;
@@ -304,217 +326,49 @@ where
     }
 }
 
-/// A Sova transaction pool. This pool is closely associated with the
-/// Optimism design except the L1Block validations are modified to validate
-/// Bitcoin L1Block data.
-#[derive(Debug, Clone)]
-pub struct SovaPoolBuilder<T = reth_optimism_txpool::OpPooledTransaction> {
-    /// Enforced overrides that are applied to the pool config.
-    pub pool_config_overrides: PoolBuilderConfigOverrides,
-    /// Enable transaction conditionals.
-    pub enable_tx_conditional: bool,
-    /// Supervisor client url
-    pub supervisor_http: String,
-    /// Supervisor safety level
-    pub supervisor_safety_level: SafetyLevel,
-    /// Marker for the pooled transaction type.
-    _pd: core::marker::PhantomData<T>,
-}
-
-impl<T> Default for SovaPoolBuilder<T> {
-    fn default() -> Self {
-        Self {
-            pool_config_overrides: Default::default(),
-            enable_tx_conditional: false,
-            supervisor_http: DEFAULT_SUPERVISOR_URL.to_string(),
-            supervisor_safety_level: SafetyLevel::CrossUnsafe,
-            _pd: Default::default(),
-        }
-    }
-}
-
-impl<T> SovaPoolBuilder<T> {
-    /// Sets the `enable_tx_conditional` flag on the pool builder.
-    pub fn with_enable_tx_conditional(mut self, enable_tx_conditional: bool) -> Self {
-        self.enable_tx_conditional = enable_tx_conditional;
-        self
-    }
-
-    /// Sets the [`PoolBuilderConfigOverrides`] on the pool builder.
-    pub fn with_pool_config_overrides(
-        mut self,
-        pool_config_overrides: PoolBuilderConfigOverrides,
-    ) -> Self {
-        self.pool_config_overrides = pool_config_overrides;
-        self
-    }
-
-    /// Sets the supervisor client
-    pub fn with_supervisor(
-        mut self,
-        supervisor_client: String,
-        supervisor_safety_level: SafetyLevel,
-    ) -> Self {
-        self.supervisor_http = supervisor_client;
-        self.supervisor_safety_level = supervisor_safety_level;
-        self
-    }
-}
-
-impl<Node, T> PoolBuilder<Node> for SovaPoolBuilder<T>
-where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec: OpHardforks>>,
-    T: EthPoolTransaction<Consensus = TxTy<Node::Types>>
-        + MaybeConditionalTransaction
-        + MaybeInteropTransaction,
-{
-    type Pool = SovaTransactionPool<Node::Provider, DiskFileBlobStore, T>;
-
-    async fn build_pool(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Pool> {
-        let Self {
-            pool_config_overrides,
-            ..
-        } = self;
-        let data_dir = ctx.config().datadir();
-        let blob_store = DiskFileBlobStore::open(data_dir.blobstore(), Default::default())?;
-        // supervisor used for interop
-        if ctx
-            .chain_spec()
-            .is_interop_active_at_timestamp(ctx.head().timestamp)
-            && self.supervisor_http == DEFAULT_SUPERVISOR_URL
-        {
-            info!(target: "reth::cli",
-                url=%DEFAULT_SUPERVISOR_URL,
-                "Default supervisor url is used, consider changing --rollup.supervisor-http."
-            );
-        }
-        let supervisor_client =
-            SupervisorClient::new(self.supervisor_http.clone(), self.supervisor_safety_level).await;
-
-        let validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
-            .no_eip4844()
-            .with_head_timestamp(ctx.head().timestamp)
-            .kzg_settings(ctx.kzg_settings()?)
-            .with_additional_tasks(
-                pool_config_overrides
-                    .additional_validation_tasks
-                    .unwrap_or_else(|| ctx.config().txpool.additional_validation_tasks),
-            )
-            .build_with_tasks(ctx.task_executor().clone(), blob_store.clone())
-            .map(|validator| {
-                SovaTransactionValidator::new(validator)
-                    // In --dev mode we can't require gas fees because we're unable to decode
-                    // the L1 block info
-                    .require_l1_data_gas_fee(!ctx.config().dev.dev)
-                    .with_supervisor(supervisor_client.clone())
-            });
-
-        let transaction_pool = reth_transaction_pool::Pool::new(
-            validator,
-            CoinbaseTipOrdering::default(),
-            blob_store,
-            pool_config_overrides.apply(ctx.pool_config()),
-        );
-        info!(target: "reth::cli", "Transaction pool initialized");
-
-        // spawn txpool maintenance tasks
-        {
-            let pool = transaction_pool.clone();
-            let chain_events = ctx.provider().canonical_state_stream();
-            let client = ctx.provider().clone();
-            if !ctx.config().txpool.disable_transactions_backup {
-                // Use configured backup path or default to data dir
-                let transactions_path = ctx
-                    .config()
-                    .txpool
-                    .transactions_backup_path
-                    .clone()
-                    .unwrap_or_else(|| data_dir.txpool_transactions());
-
-                let transactions_backup_config =
-                    reth_transaction_pool::maintain::LocalTransactionBackupConfig::with_local_txs_backup(transactions_path);
-
-                ctx.task_executor()
-                    .spawn_critical_with_graceful_shutdown_signal(
-                        "local transactions backup task",
-                        |shutdown| {
-                            reth_transaction_pool::maintain::backup_local_transactions_task(
-                                shutdown,
-                                pool.clone(),
-                                transactions_backup_config,
-                            )
-                        },
-                    );
-            }
-
-            // spawn the main maintenance task
-            ctx.task_executor().spawn_critical(
-                "txpool maintenance task",
-                reth_transaction_pool::maintain::maintain_transaction_pool_future(
-                    client,
-                    pool.clone(),
-                    chain_events,
-                    ctx.task_executor().clone(),
-                    reth_transaction_pool::maintain::MaintainPoolConfig {
-                        max_tx_lifetime: pool.config().max_queued_lifetime,
-                        no_local_exemptions: transaction_pool
-                            .config()
-                            .local_transactions_config
-                            .no_exemptions,
-                        ..Default::default()
-                    },
-                ),
-            );
-            debug!(target: "reth::cli", "Spawned txpool maintenance task");
-
-            // spawn the Op txpool maintenance task
-            let chain_events = ctx.provider().canonical_state_stream();
-            ctx.task_executor().spawn_critical(
-                "Op txpool interop maintenance task",
-                reth_optimism_txpool::maintain::maintain_transaction_pool_interop_future(
-                    pool.clone(),
-                    chain_events,
-                    supervisor_client,
-                ),
-            );
-            debug!(target: "reth::cli", "Spawned Op interop txpool maintenance task");
-
-            if self.enable_tx_conditional {
-                // spawn the Op txpool maintenance task
-                let chain_events = ctx.provider().canonical_state_stream();
-                ctx.task_executor().spawn_critical(
-                    "Op txpool conditional maintenance task",
-                    reth_optimism_txpool::maintain::maintain_transaction_pool_conditional_future(
-                        pool,
-                        chain_events,
-                    ),
-                );
-                debug!(target: "reth::cli", "Spawned Op conditional txpool maintenance task");
-            }
-        }
-
-        Ok(transaction_pool)
-    }
-}
-
 /// A Sova payload builder service
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct SovaPayloadBuilder<Txs = ()> {
     pub config: SovaConfig,
     pub bitcoin_client: Arc<BitcoinClient>,
+    /// By default the pending block equals the latest block
+    /// to save resources and not leak txs from the tx-pool,
+    /// this flag enables computing of the pending block
+    /// from the tx-pool instead.
+    ///
+    /// If `compute_pending_block` is not enabled, the payload builder
+    /// will use the payload attributes from the latest block. Note
+    /// that this flag is not yet functional.
+    pub compute_pending_block: bool,
     /// The type responsible for yielding the best transactions for the payload if mempool
     /// transactions are allowed.
     pub best_transactions: Txs,
+    /// This data availability configuration specifies constraints for the payload builder
+    /// when assembling payloads
+    pub da_config: OpDAConfig,
 }
 
 impl SovaPayloadBuilder {
-    pub fn new(config: SovaConfig, bitcoin_client: Arc<BitcoinClient>) -> Self {
+    /// Create a new instance with the given `compute_pending_block` flag and data availability config.
+    pub fn new(
+        config: SovaConfig,
+        bitcoin_client: Arc<BitcoinClient>,
+        compute_pending_block: bool,
+    ) -> Self {
         Self {
             config,
             bitcoin_client,
+            compute_pending_block,
             best_transactions: (),
+            da_config: OpDAConfig::default(),
         }
+    }
+
+    /// Configure the data availability configuration for the OP payload builder.
+    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+        self.da_config = da_config;
+        self
     }
 }
 
@@ -525,12 +379,16 @@ impl<Txs> SovaPayloadBuilder<Txs> {
         let Self {
             config,
             bitcoin_client,
+            compute_pending_block,
+            da_config,
             ..
         } = self;
         SovaPayloadBuilder {
             config,
             bitcoin_client,
+            compute_pending_block,
             best_transactions,
+            da_config,
         }
     }
 
@@ -553,17 +411,18 @@ impl<Txs> SovaPayloadBuilder<Txs> {
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,
+        Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>>,
         Txs: OpPayloadTransactions<Pool::Transaction>,
     {
         let payload_builder = sova_payload::SovaPayloadBuilder::new(
             ctx.provider().clone(),
             pool,
             evm_config,
-            EthereumBuilderConfig::new().with_gas_limit(ctx.payload_builder_config().gas_limit()),
+            OpBuilderConfig { da_config: self.da_config.clone() },
             self.bitcoin_client.clone(),
         )
-        .with_transactions(self.best_transactions.clone());
-
+        .with_transactions(self.best_transactions.clone())
+        .set_compute_pending_block(self.compute_pending_block);
         Ok(payload_builder)
     }
 }
@@ -655,37 +514,6 @@ where
             evm_config.clone(),
             SovaBlockExecutorProvider::new(evm_config, self.bitcoin_client),
         ))
-    }
-}
-
-/// A type that knows how to build the Sova network.
-/// Similar to the Ethereum network builder, this builder spawns
-/// an Ethereum p2p tx pool and p2p eth request handler.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct SovaNetworkBuilder;
-
-impl<Node, Pool> NetworkBuilder<Node, Pool> for SovaNetworkBuilder
-where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives>>,
-    Pool: TransactionPool<
-            Transaction: PoolTransaction<
-                Consensus = TxTy<Node::Types>,
-                Pooled = OpPooledTransaction,
-            >,
-        > + Unpin
-        + 'static,
-{
-    type Primitives = OpNetworkPrimitives;
-
-    async fn build_network(
-        self,
-        ctx: &BuilderContext<Node>,
-        pool: Pool,
-    ) -> eyre::Result<NetworkHandle<Self::Primitives>> {
-        let network = ctx.network_builder().await?;
-        let handle = ctx.start_network(network, pool);
-        info!(target: "reth::cli", enode=%handle.local_node_record(), "P2P networking initialized");
-        Ok(handle)
     }
 }
 

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -60,7 +60,8 @@ use revm::{
 
 use sova_cli::SovaConfig;
 use sova_evm::{
-    BitcoinClient, MyEvmConfig, SovaL1BlockInfo, WithInspector, L1_BLOCK_CONTRACT_ADDRESS, L1_BLOCK_CONTRACT_CALLER
+    BitcoinClient, MyEvmConfig, SovaL1BlockInfo, WithInspector, L1_BLOCK_CONTRACT_ADDRESS,
+    L1_BLOCK_CONTRACT_CALLER,
 };
 
 sol!(
@@ -95,11 +96,7 @@ pub struct SovaPayloadBuilder<Pool, Client, Evm = MyEvmConfig, Txs = ()> {
 
 impl<Pool, Client, Evm> SovaPayloadBuilder<Pool, Client, Evm> {
     /// `SovaPayloadBuilder` constructor with Sova and Bitcoin integration.
-    pub fn new(
-        pool: Pool,
-        client: Client,
-        evm_config: Evm,
-    ) -> Self {
+    pub fn new(pool: Pool, client: Client, evm_config: Evm) -> Self {
         Self::with_builder_config(pool, client, evm_config, Default::default())
     }
 
@@ -195,7 +192,7 @@ where
     /// Given build arguments including an Optimism client, transaction pool,
     /// and configuration, this function creates a transaction payload. Returns
     /// a result indicating success with the payload or an error in case of failure.
-    /// 
+    ///
     /// NOTE(powvt): This implementation of the Optimism PayloadBuilder includes some Sova
     /// specific differences. The primary differences are applying the revert state changes
     /// from the sentinel cache and also applying the Sova Bitcoin context
@@ -282,7 +279,7 @@ where
     }
 
     /// Computes the witness for the payload.
-    /// 
+    ///
     /// TODO(powvt): Deal with call to Bitcoin node here.
     /// Ideally that data is already in the attributes recieved from the sequencer.
     pub fn payload_witness(
@@ -372,7 +369,8 @@ where
         attributes: &mut OpPayloadAttributes,
     ) -> Result<(), PayloadBuilderError> {
         // Fetch the current Bitcoin block info from the Bitcoin client
-        let bitcoin_block_info: SovaL1BlockInfo = match self.bitcoin_client.get_current_block_info() {
+        let bitcoin_block_info: SovaL1BlockInfo = match self.bitcoin_client.get_current_block_info()
+        {
             Ok(info) => info,
             Err(err) => {
                 warn!(target: "payload_builder", "Failed to get block info from BTC client: {}", err);
@@ -422,7 +420,10 @@ where
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         let pool = self.pool.clone();
-        self.build_payload(args, |attrs| self.best_transactions.best_transactions(pool.clone(), attrs))
+        self.build_payload(args, |attrs| {
+            self.best_transactions
+                .best_transactions(pool.clone(), attrs)
+        })
     }
 
     fn on_missing_payload(
@@ -446,9 +447,11 @@ where
             cancel: Default::default(),
             best_payload: None,
         };
-        self.build_payload(args, |_| NoopPayloadTransactions::<Pool::Transaction>::default())?
-            .into_payload()
-            .ok_or_else(|| PayloadBuilderError::MissingPayload)
+        self.build_payload(args, |_| {
+            NoopPayloadTransactions::<Pool::Transaction>::default()
+        })?
+        .into_payload()
+        .ok_or_else(|| PayloadBuilderError::MissingPayload)
     }
 }
 

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -19,7 +19,6 @@ use reth_basic_payload_builder::{
 use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError};
-use reth_ethereum_payload_builder::EthereumBuilderConfig;
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutor},
     ConfigureEvm, Database, Evm,
@@ -51,7 +50,7 @@ use reth_revm::{
     DatabaseCommit,
 };
 use reth_storage_api::errors::ProviderError;
-use reth_tracing::tracing::{debug, info, trace, warn};
+use reth_tracing::tracing::{debug, trace, warn};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
 
 use revm::{
@@ -61,7 +60,7 @@ use revm::{
 
 use sova_cli::SovaConfig;
 use sova_evm::{
-    BitcoinClient, MyEvmConfig, WithInspector, L1_BLOCK_CONTRACT_ADDRESS, L1_BLOCK_CONTRACT_CALLER,
+    BitcoinClient, MyEvmConfig, SovaL1BlockInfo, WithInspector, L1_BLOCK_CONTRACT_ADDRESS, L1_BLOCK_CONTRACT_CALLER
 };
 
 sol!(
@@ -71,7 +70,7 @@ sol!(
     );
 );
 
-/// Sova payload builder that extends the Optimism payload builder with Bitcoin integration
+/// Sova payload builder that extends the Optimism payload builder with Bitcoin integrations
 #[derive(Debug, Clone)]
 pub struct SovaPayloadBuilder<Pool, Client, Evm = MyEvmConfig, Txs = ()> {
     /// The rollup's compute pending block configuration option.
@@ -97,38 +96,25 @@ pub struct SovaPayloadBuilder<Pool, Client, Evm = MyEvmConfig, Txs = ()> {
 impl<Pool, Client, Evm> SovaPayloadBuilder<Pool, Client, Evm> {
     /// `SovaPayloadBuilder` constructor with Sova and Bitcoin integration.
     pub fn new(
-        client: Client,
         pool: Pool,
+        client: Client,
         evm_config: Evm,
-        config: OpBuilderConfig,
-        bitcoin_client: Arc<BitcoinClient>,
     ) -> Self {
-        Self {
-            compute_pending_block: true,
-            client,
-            pool,
-            evm_config,
-            config,
-            best_transactions: (),
-            sova_config: SovaConfig::default(),
-            bitcoin_client,
-        }
+        Self::with_builder_config(pool, client, evm_config, Default::default())
     }
 
     /// Configures the builder with the given [`OpBuilderConfig`].
     pub fn with_builder_config(
-        client: Client,
         pool: Pool,
+        client: Client,
         evm_config: Evm,
-        builder_config: EthereumBuilderConfig,
         config: OpBuilderConfig,
     ) -> Self {
         Self {
-            client,
             pool,
-            evm_config,
-            builder_config,
+            client,
             compute_pending_block: true,
+            evm_config,
             config,
             best_transactions: (),
             sova_config: SovaConfig::default(),
@@ -136,7 +122,7 @@ impl<Pool, Client, Evm> SovaPayloadBuilder<Pool, Client, Evm> {
         }
     }
 
-    /// Configures the builder with Sova and Bitcoin integration.
+    /// Configures the `SovaPayloadBuilder` builder with Bitcoin integrations.
     pub fn with_sova_integration(
         mut self,
         sova_config: SovaConfig,
@@ -144,12 +130,6 @@ impl<Pool, Client, Evm> SovaPayloadBuilder<Pool, Client, Evm> {
     ) -> Self {
         self.sova_config = sova_config;
         self.bitcoin_client = bitcoin_client;
-        self
-    }
-
-    /// Configure the data availability configuration for the OP builder.
-    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
-        self.config.da_config = da_config;
         self
     }
 }
@@ -161,16 +141,6 @@ impl<Pool, Client, Evm, Txs> SovaPayloadBuilder<Pool, Client, Evm, Txs> {
         self
     }
 
-    /// Enables the rollup's compute pending block configuration option.
-    pub const fn compute_pending_block(self) -> Self {
-        self.set_compute_pending_block(true)
-    }
-
-    /// Returns the rollup's compute pending block configuration option.
-    pub const fn is_compute_pending_block(&self) -> bool {
-        self.compute_pending_block
-    }
-
     /// Configures the type responsible for yielding the transactions that should be included in the
     /// payload.
     pub fn with_transactions<T>(
@@ -180,9 +150,8 @@ impl<Pool, Client, Evm, Txs> SovaPayloadBuilder<Pool, Client, Evm, Txs> {
         let Self {
             pool,
             client,
-            evm_config,
-            builder_config,
             compute_pending_block,
+            evm_config,
             config,
             sova_config,
             bitcoin_client,
@@ -191,33 +160,53 @@ impl<Pool, Client, Evm, Txs> SovaPayloadBuilder<Pool, Client, Evm, Txs> {
         SovaPayloadBuilder {
             pool,
             client,
-            evm_config,
-            builder_config,
             compute_pending_block,
-            config,
+            evm_config,
             best_transactions,
+            config,
             sova_config,
             bitcoin_client,
         }
     }
+
+    /// Enables the rollup's compute pending block configuration option.
+    pub const fn compute_pending_block(self) -> Self {
+        self.set_compute_pending_block(true)
+    }
+
+    /// Returns the rollup's compute pending block configuration option.
+    pub const fn is_compute_pending_block(&self) -> bool {
+        self.compute_pending_block
+    }
 }
 
-impl<Pool, Client, Evm, N, Txs> SovaPayloadBuilder<Pool, Client, Evm, Txs>
+impl<Pool, Client, Evm, N, T> SovaPayloadBuilder<Pool, Client, Evm, T>
 where
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
     N: OpPayloadPrimitives,
     Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes> + WithInspector,
-    Txs: OpPayloadTransactions<Pool::Transaction>,
 {
-    /// Builds the payload on top of the state.
-    fn build_payload<'a, T>(
+    /// Constructs an Optimism payload from the transactions sent via the
+    /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
+    /// the payload attributes, the transaction pool will be ignored and the only transactions
+    /// included in the payload will be those sent through the attributes.
+    ///
+    /// Given build arguments including an Optimism client, transaction pool,
+    /// and configuration, this function creates a transaction payload. Returns
+    /// a result indicating success with the payload or an error in case of failure.
+    /// 
+    /// NOTE(powvt): This implementation of the Optimism PayloadBuilder includes some Sova
+    /// specific differences. The primary differences are applying the revert state changes
+    /// from the sentinel cache and also applying the Sova Bitcoin context
+    /// transactions (SovaL1Block).
+    fn build_payload<'a, Txs>(
         &self,
         args: BuildArguments<OpPayloadBuilderAttributes<N::SignedTx>, OpBuiltPayload<N>>,
-        best: impl Fn(BestTransactionsAttributes) -> T + Send + Sync + 'a,
+        best: impl Fn(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
     ) -> Result<BuildOutcome<OpBuiltPayload<N>>, PayloadBuilderError>
     where
-        T: PayloadTransactions<
+        Txs: PayloadTransactions<
             Transaction: PoolTransaction<Consensus = N::SignedTx> + MaybeInteropTransaction,
         >,
     {
@@ -228,7 +217,12 @@ where
             best_payload,
         } = args;
 
-        let mut sova_payload_attrs = OpPayloadAttributes {
+        // TODO(powvt): investigate if this can be None?
+        if config.attributes.transactions.is_empty() {
+            warn!(target: "payload_builder", "No sequencer txs recieved");
+        }
+
+        let mut op_payload_attrs = OpPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: config.attributes.timestamp(),
                 prev_randao: config.attributes.prev_randao(),
@@ -236,6 +230,7 @@ where
                 withdrawals: Some(config.attributes.withdrawals().to_vec()),
                 parent_beacon_block_root: config.attributes.parent_beacon_block_root(),
             },
+            // TODO(powvt): smae comment as above, can we do Some() here safely?
             transactions: Some(
                 config
                     .attributes
@@ -250,7 +245,7 @@ where
         };
 
         // Inject Bitcoin data
-        if let Err(err) = self.inject_bitcoin_data_to_payload_attrs(&mut sova_payload_attrs) {
+        if let Err(err) = self.inject_bitcoin_data_to_payload_attrs(&mut op_payload_attrs) {
             warn!(target: "payload_builder", "Failed to inject Bitcoin data: {}", err);
             // Continue with payload building even if Bitcoin data injection fails
         }
@@ -260,7 +255,7 @@ where
             parent_header: config.parent_header.clone(),
             attributes: OpPayloadBuilderAttributes::try_new(
                 config.attributes.parent(),
-                sova_payload_attrs,
+                op_payload_attrs,
                 3, // Assuming version 3, adjust if needed
             )
             .map_err(PayloadBuilderError::other)?,
@@ -275,7 +270,7 @@ where
             best_payload,
         };
 
-        let builder = MyBuilder::new(best, self.evm_config.clone());
+        let builder = SovaBuilder::new(best, self.evm_config.clone());
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let state = StateProviderDatabase::new(&state_provider);
@@ -287,16 +282,15 @@ where
     }
 
     /// Computes the witness for the payload.
+    /// 
+    /// TODO(powvt): Deal with call to Bitcoin node here.
+    /// Ideally that data is already in the attributes recieved from the sequencer.
     pub fn payload_witness(
         &self,
         parent: SealedHeader,
-        mut attributes: OpPayloadAttributes,
+        attributes: OpPayloadAttributes,
     ) -> Result<ExecutionWitness, PayloadBuilderError> {
-        // Inject Bitcoin data
-        if let Err(err) = self.inject_bitcoin_data_to_payload_attrs(&mut attributes) {
-            warn!(target: "payload_builder", "Failed to inject Bitcoin data: {}", err);
-            // Continue with payload building even if Bitcoin data injection fails
-        }
+        // NOTE(powvt): NOT injecting Bitcoion data into attributes here
 
         let attributes = OpPayloadBuilderAttributes::try_new(parent.hash(), attributes, 3)
             .map_err(PayloadBuilderError::other)?;
@@ -316,7 +310,7 @@ where
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
 
-        let builder = MyBuilder::new(
+        let builder = SovaBuilder::new(
             |_| NoopPayloadTransactions::<Pool::Transaction>::default(),
             self.evm_config.clone(),
         );
@@ -325,7 +319,7 @@ where
 
     pub fn update_l1_block_source() -> B256 {
         UpgradeDepositSource {
-            intent: String::from("Satoshi: L1 Block Update"),
+            intent: String::from("Sova: L1 Block Update"),
         }
         .source_hash()
     }
@@ -372,43 +366,33 @@ where
         buffer.freeze().into()
     }
 
-    /// Add the bitcoin data transaction to the payload attributes
-    pub fn add_bitcoin_data_to_payload_attrs(
-        block_height: u64,
-        block_hash: B256,
-    ) -> Option<Vec<Bytes>> {
-        // Generate the deposit transaction
-        let tx_bytes = Self::create_bitcoin_data_deposit_tx(block_height, block_hash);
-
-        // Create vector with this transaction
-        Some(vec![tx_bytes])
-    }
-
     /// Inject Bitcoin data into a new block via a deposit transaction
     pub fn inject_bitcoin_data_to_payload_attrs(
         &self,
         attributes: &mut OpPayloadAttributes,
     ) -> Result<(), PayloadBuilderError> {
         // Fetch the current Bitcoin block info from the Bitcoin client
-        let bitcoin_block_info = match self.bitcoin_client.get_current_block_info() {
+        let bitcoin_block_info: SovaL1BlockInfo = match self.bitcoin_client.get_current_block_info() {
             Ok(info) => info,
             Err(err) => {
-                warn!(target: "payload_builder", "Failed to fetch Bitcoin block info: {}", err);
-                return Err(PayloadBuilderError::other(RethError::msg(format!(
-                    "Failed to fetch Bitcoin block info: {}",
-                    err
-                ))));
+                warn!(target: "payload_builder", "Failed to get block info from BTC client: {}", err);
+                SovaL1BlockInfo::default()
             }
         };
 
         // Generate the deposit transaction bytes with just height and hash
-        let transactions = Self::add_bitcoin_data_to_payload_attrs(
+        let btc_tx_bytes = Self::create_bitcoin_data_deposit_tx(
             bitcoin_block_info.current_block_height,
             bitcoin_block_info.block_hash_six_blocks_back,
         );
 
-        // Set the transactions in the payload attributes
-        attributes.transactions = transactions;
+        // Append the Bitcoin transaction to the existing transactions.
+        if let Some(ref mut txs) = attributes.transactions {
+            txs.push(btc_tx_bytes);
+        } else {
+            // If there are no transactions yet, create a vector with just the Bitcoin transaction
+            attributes.transactions = Some(vec![btc_tx_bytes]);
+        }
 
         debug!(
             target: "payload_builder",
@@ -421,7 +405,7 @@ where
     }
 }
 
-// Implementation of the PayloadBuilder trait for SovaPayloadBuilder
+/// Implementation of the [`PayloadBuilder`] trait for [`SovaPayloadBuilder`].
 impl<Pool, Client, Evm, N, Txs> PayloadBuilder for SovaPayloadBuilder<Pool, Client, Evm, Txs>
 where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
@@ -438,10 +422,7 @@ where
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         let pool = self.pool.clone();
-        self.build_payload(args, |attrs| {
-            self.best_transactions
-                .best_transactions(pool.clone(), attrs)
-        })
+        self.build_payload(args, |attrs| self.best_transactions.best_transactions(pool.clone(), attrs))
     }
 
     fn on_missing_payload(
@@ -453,6 +434,8 @@ where
         MissingPayloadBehaviour::AwaitInProgress
     }
 
+    // NOTE: this should only be used for testing purposes because this doesn't have access to L1
+    // system txs, hence on_missing_payload we return [MissingPayloadBehaviour::AwaitInProgress].
     fn build_empty_payload(
         &self,
         config: PayloadConfig<Self::Attributes>,
@@ -463,17 +446,30 @@ where
             cancel: Default::default(),
             best_payload: None,
         };
-        self.build_payload(args, |_| {
-            NoopPayloadTransactions::<Pool::Transaction>::default()
-        })?
-        .into_payload()
-        .ok_or_else(|| PayloadBuilderError::MissingPayload)
+        self.build_payload(args, |_| NoopPayloadTransactions::<Pool::Transaction>::default())?
+            .into_payload()
+            .ok_or_else(|| PayloadBuilderError::MissingPayload)
     }
 }
 
 /// The type that builds the payload.
+///
+/// Payload building for Sova is composed of several steps.
+/// The first steps are mandatory and defined by the protocol.
+///
+/// 1. First all System calls are applied.
+/// 2. After canyon the forced deployed `create2deployer` must be loaded
+/// 3. All sequencer transactions are executed (part of the payload attributes)
+/// 4. All SovaL1Block injected transactions are applied
+///
+/// Depending on whether the node acts as a sequencer and is allowed to include additional
+/// transactions (`no_tx_pool == false`):
+/// 4. include additional transactions
+///
+/// And finally
+/// 5. build the block: compute all roots (txs, state)
 #[derive(derive_more::Debug)]
-pub struct MyBuilder<'a, Txs, Evm> {
+pub struct SovaBuilder<'a, Txs, Evm> {
     /// Yields the best transaction to include if transactions from the mempool are allowed.
     #[debug(skip)]
     best: Box<dyn Fn(BestTransactionsAttributes) -> Txs + 'a>,
@@ -482,8 +478,8 @@ pub struct MyBuilder<'a, Txs, Evm> {
     evm_config: Evm,
 }
 
-impl<'a, Txs, Evm> MyBuilder<'a, Txs, Evm> {
-    /// Creates a new [`MyBuilder`].
+impl<'a, Txs, Evm> SovaBuilder<'a, Txs, Evm> {
+    /// Creates a new [`SovaBuilder`].
     pub fn new(
         best: impl Fn(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
         evm_config: Evm,
@@ -495,7 +491,7 @@ impl<'a, Txs, Evm> MyBuilder<'a, Txs, Evm> {
     }
 }
 
-impl<Txs, Evm, N> MyBuilder<'_, Txs, Evm>
+impl<Txs, Evm, N> SovaBuilder<'_, Txs, Evm>
 where
     Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes> + WithInspector,
     N: OpPayloadPrimitives,
@@ -637,8 +633,8 @@ where
             PayloadBuilderError::Internal(err.into())
         })?;
 
-        // 2. execute L1Block transactions
-        let mut info = ctx.execute_l1_block_transactions(&mut builder)?;
+        // 2. execute SovaL1Block transactions
+        let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
 
         // 3. if mem pool transactions are requested we execute them
         if !ctx.attributes().no_tx_pool {
@@ -759,7 +755,7 @@ where
         let mut builder = ctx.block_builder(&mut db)?;
 
         builder.apply_pre_execution_changes()?;
-        ctx.execute_l1_block_transactions(&mut builder)?;
+        ctx.execute_sequencer_transactions(&mut builder)?;
         builder.into_executor().apply_post_execution_changes()?;
 
         let ExecutionWitnessRecord {
@@ -877,7 +873,7 @@ where
     }
 
     /// Executes all sequencer transactions that are included in the payload attributes.
-    pub fn execute_l1_block_transactions(
+    pub fn execute_sequencer_transactions(
         &self,
         builder: &mut impl BlockBuilder<Primitives = Evm::Primitives>,
     ) -> Result<ExecutionInfo, PayloadBuilderError> {
@@ -902,7 +898,7 @@ where
                     PayloadBuilderError::other(OpPayloadBuilderError::TransactionEcRecoverFailed)
                 })?;
 
-            info!("sequencer tx {:?}", sequencer_tx);
+            debug!("sequencer tx {:?}", sequencer_tx);
 
             let gas_used = match builder.execute_transaction(sequencer_tx.clone()) {
                 Ok(gas_used) => gas_used,

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -75,6 +75,7 @@ sol!(
 #[derive(Debug, Clone)]
 pub struct SovaPayloadBuilder<Pool, Client, Evm = MyEvmConfig, Txs = ()> {
     /// The rollup's compute pending block configuration option.
+    // TODO(clabby): Implement this feature.
     pub compute_pending_block: bool,
     /// The type responsible for creating the evm.
     pub evm_config: Evm,
@@ -83,8 +84,6 @@ pub struct SovaPayloadBuilder<Pool, Client, Evm = MyEvmConfig, Txs = ()> {
     /// Node client.
     pub client: Client,
     /// Ethereum builder configuration.
-    pub builder_config: EthereumBuilderConfig,
-    /// Settings for the builder, e.g. DA settings.
     pub config: OpBuilderConfig,
     /// The type responsible for yielding the best transactions for the payload if mempool
     /// transactions are allowed.
@@ -101,16 +100,15 @@ impl<Pool, Client, Evm> SovaPayloadBuilder<Pool, Client, Evm> {
         client: Client,
         pool: Pool,
         evm_config: Evm,
-        builder_config: EthereumBuilderConfig,
+        config: OpBuilderConfig,
         bitcoin_client: Arc<BitcoinClient>,
     ) -> Self {
         Self {
+            compute_pending_block: true,
             client,
             pool,
             evm_config,
-            builder_config,
-            compute_pending_block: true,
-            config: OpBuilderConfig::default(),
+            config,
             best_transactions: (),
             sova_config: SovaConfig::default(),
             bitcoin_client,

--- a/crates/sova-evm/src/execute.rs
+++ b/crates/sova-evm/src/execute.rs
@@ -104,11 +104,7 @@ where
         block: &RecoveredBlock<<<F as ConfigureEvm>::Primitives as NodePrimitives>::Block>,
     ) -> Result<(), BlockExecutionError> {
         for (idx, tx) in block.body().transactions().iter().enumerate() {
-            info!(
-                "idx {}: tx: {:?}",
-                idx,
-                tx
-            );
+            info!("idx {}: tx: {:?}", idx, tx);
         }
 
         // Validate the SECOND transaction (index 1) for BTC data

--- a/crates/sova-evm/src/execute.rs
+++ b/crates/sova-evm/src/execute.rs
@@ -103,7 +103,18 @@ where
         &self,
         block: &RecoveredBlock<<<F as ConfigureEvm>::Primitives as NodePrimitives>::Block>,
     ) -> Result<(), BlockExecutionError> {
-        match block.body().transactions().first() {
+        for (idx, tx) in block.body().transactions().iter().enumerate() {
+            info!(
+                "idx {}: tx: {:?}",
+                idx,
+                tx
+            );
+        }
+
+        // Validate the SECOND transaction (index 1) for BTC data
+        //
+        // TODO(powvt): Make this resilient to more than one sequencer tx
+        match block.body().transactions().get(1) {
             Some(tx) => {
                 // Extract the input data from the first transaction
                 let input = tx.input();
@@ -121,6 +132,8 @@ where
                     debug!(target: "execution", "Genesis block - skipping Bitcoin block validation");
                     Ok(())
                 } else if input[0..4] == L1_BLOCK_SATOSHI_SELECTOR {
+                    // TODO(powvt): improve validations of BTC data
+
                     if input.len() < 68 {
                         // 4 bytes selector + 32 bytes blockHeight + 32 bytes blockHash
                         return Err(BlockExecutionError::other(RethError::msg(

--- a/crates/sova-evm/src/execute.rs
+++ b/crates/sova-evm/src/execute.rs
@@ -2,47 +2,30 @@ extern crate alloc;
 
 use std::sync::Arc;
 
-use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 
-use alloy_consensus::{BlockHeader, Eip658Value, Header, Transaction, TxReceipt};
-use alloy_eips::{
-    eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS, eip7685::Requests, Encodable2718, Typed2718,
-};
-use alloy_evm::block::ExecutableTx;
+use alloy_consensus::{BlockHeader, Transaction};
 
-use alloy_op_evm::{block::receipt_builder::OpReceiptBuilder, OpBlockExecutionCtx};
 use alloy_primitives::{
     map::foldhash::{HashMap, HashMapExt},
-    Address, Bytes, B256, U256,
+    Address, B256, U256,
 };
-use op_alloy_consensus::OpDepositReceipt;
-use op_revm::transaction::deposit::DEPOSIT_TRANSACTION_TYPE;
-use reth_errors::{BlockValidationError, RethError};
+
+use reth_errors::RethError;
 use reth_evm::{
-    block::{
-        BlockExecutor, InternalBlockExecutionError, StateChangePostBlockSource, StateChangeSource,
-        SystemCaller,
-    },
-    eth::{
-        eip6110::{self, accumulate_deposits_from_receipts},
-        receipt_builder::ReceiptBuilderCtx,
-    },
+    block::{BlockExecutor, InternalBlockExecutionError},
     execute::{BlockExecutionError, BlockExecutorProvider, Executor},
-    state_change::{balance_increment_state, post_block_balance_increments},
-    ConfigureEvm, Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, OnStateHook,
+    ConfigureEvm, Database, Evm, EvmFactory, OnStateHook,
 };
 use reth_node_api::{BlockBody, NodePrimitives};
-use reth_optimism_forks::OpHardforks;
-use reth_primitives::{Log, RecoveredBlock};
+use reth_primitives::RecoveredBlock;
 use reth_provider::BlockExecutionResult;
 use reth_revm::{
-    context::result::ExecutionResult,
     db::{states::bundle_state::BundleRetention, State},
     state::Account,
     DatabaseCommit,
 };
 use reth_tracing::tracing::{debug, info, warn};
-use revm::context::result::ResultAndState;
 
 use crate::{BitcoinClient, WithInspector, L1_BLOCK_SATOSHI_SELECTOR};
 
@@ -490,269 +473,5 @@ where
 
     fn size_hint(&self) -> usize {
         self.db.bundle_state.size_hint()
-    }
-}
-
-/// Block executor for Optimism.
-#[derive(Debug)]
-pub struct MyBlockExecutor<Evm, R: OpReceiptBuilder, Spec> {
-    /// Spec.
-    spec: Spec,
-    /// Receipt builder.
-    receipt_builder: R,
-
-    /// Context for block execution.
-    ctx: OpBlockExecutionCtx,
-    /// The EVM used by executor.
-    evm: Evm,
-    /// Receipts of executed transactions.
-    receipts: Vec<R::Receipt>,
-    /// Total gas used by executed transactions.
-    gas_used: u64,
-    /// Whether Regolith hardfork is active.
-    is_regolith: bool,
-    /// Utility to call system smart contracts.
-    system_caller: SystemCaller<Spec>,
-}
-
-impl<E, R, Spec> MyBlockExecutor<E, R, Spec>
-where
-    E: Evm,
-    R: OpReceiptBuilder,
-    Spec: OpHardforks + Clone,
-{
-    /// Creates a new [`OpBlockExecutor`].
-    pub fn new(evm: E, ctx: OpBlockExecutionCtx, spec: Spec, receipt_builder: R) -> Self {
-        Self {
-            is_regolith: spec.is_regolith_active_at_timestamp(evm.block().timestamp),
-            evm,
-            system_caller: SystemCaller::new(spec.clone()),
-            spec,
-            receipt_builder,
-            receipts: Vec::new(),
-            gas_used: 0,
-            ctx,
-        }
-    }
-}
-
-impl<E, R, Spec> MyBlockExecutor<E, R, Spec>
-where
-    R: OpReceiptBuilder,
-{
-    /// Find deposit logs in a list of receipts, and return the concatenated
-    /// deposit request bytestring.
-    ///
-    /// The address of the deposit contract is taken from the chain spec, and
-    /// defaults to [`MAINNET_DEPOSIT_CONTRACT_ADDRESS`] if not specified in
-    /// the chain spec.
-    pub fn parse_deposits_from_receipts<'a, I, Receipt>(
-        receipts: I,
-    ) -> Result<Bytes, BlockValidationError>
-    where
-        I: IntoIterator<Item = &'a Receipt>,
-        Receipt: TxReceipt<Log = Log> + 'a,
-    {
-        let mut out = Vec::new();
-        accumulate_deposits_from_receipts(MAINNET_DEPOSIT_CONTRACT_ADDRESS, receipts, &mut out)?;
-        Ok(out.into())
-    }
-}
-
-impl<'db, DB, E, R, Spec> BlockExecutor for MyBlockExecutor<E, R, Spec>
-where
-    DB: Database + 'db,
-    E: Evm<
-        DB = &'db mut State<DB>,
-        Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
-    >,
-    R: OpReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
-    Spec: OpHardforks,
-{
-    type Transaction = R::Transaction;
-    type Receipt = R::Receipt;
-    type Evm = E;
-
-    fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
-        // Set state clear flag if the block is after the Spurious Dragon hardfork.
-        let state_clear_flag = self
-            .spec
-            .is_spurious_dragon_active_at_block(self.evm.block().number);
-        self.evm.db_mut().set_state_clear_flag(state_clear_flag);
-
-        self.system_caller
-            .apply_blockhashes_contract_call(self.ctx.parent_hash, &mut self.evm)?;
-        self.system_caller
-            .apply_beacon_root_contract_call(self.ctx.parent_beacon_block_root, &mut self.evm)?;
-
-        Ok(())
-    }
-
-    fn execute_transaction_with_result_closure(
-        &mut self,
-        tx: impl ExecutableTx<Self>,
-        f: impl FnOnce(&ExecutionResult<<Self::Evm as Evm>::HaltReason>),
-    ) -> Result<u64, BlockExecutionError> {
-        let is_deposit = tx.tx().ty() == DEPOSIT_TRANSACTION_TYPE;
-
-        // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
-        // must be no greater than the block’s gasLimit.
-        let block_available_gas = self.evm.block().gas_limit - self.gas_used;
-        if tx.tx().gas_limit() > block_available_gas && (self.is_regolith || !is_deposit) {
-            return Err(
-                BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
-                    transaction_gas_limit: tx.tx().gas_limit(),
-                    block_available_gas,
-                }
-                .into(),
-            );
-        }
-
-        // Cache the depositor account prior to the state transition for the deposit nonce.
-        //
-        // Note that this *only* needs to be done post-regolith hardfork, as deposit nonces
-        // were not introduced in Bedrock. In addition, regular transactions don't have deposit
-        // nonces, so we don't need to touch the DB for those.
-        let depositor = (self.is_regolith && is_deposit)
-            .then(|| {
-                self.evm
-                    .db_mut()
-                    .load_cache_account(*tx.signer())
-                    .map(|acc| acc.account_info().unwrap_or_default())
-            })
-            .transpose()
-            .map_err(BlockExecutionError::other)?;
-
-        let hash = tx.tx().trie_hash();
-
-        // Execute transaction.
-        let result_and_state = self
-            .evm
-            .transact(tx)
-            .map_err(move |err| BlockExecutionError::evm(err, hash))?;
-
-        self.system_caller.on_state(
-            StateChangeSource::Transaction(self.receipts.len()),
-            &result_and_state.state,
-        );
-        let ResultAndState { result, state } = result_and_state;
-
-        f(&result);
-
-        let gas_used = result.gas_used();
-
-        // append gas used
-        self.gas_used += gas_used;
-
-        self.receipts.push(
-            match self.receipt_builder.build_receipt(ReceiptBuilderCtx {
-                tx: tx.tx(),
-                result,
-                cumulative_gas_used: self.gas_used,
-                evm: &self.evm,
-                state: &state,
-            }) {
-                Ok(receipt) => receipt,
-                Err(ctx) => {
-                    let receipt = alloy_consensus::Receipt {
-                        // Success flag was added in `EIP-658: Embedding transaction status code
-                        // in receipts`.
-                        status: Eip658Value::Eip658(ctx.result.is_success()),
-                        cumulative_gas_used: self.gas_used,
-                        logs: ctx.result.into_logs(),
-                    };
-
-                    self.receipt_builder
-                        .build_deposit_receipt(OpDepositReceipt {
-                            inner: receipt,
-                            deposit_nonce: depositor.map(|account| account.nonce),
-                            // The deposit receipt version was introduced in Canyon to indicate an
-                            // update to how receipt hashes should be computed
-                            // when set. The state transition process ensures
-                            // this is only set for post-Canyon deposit
-                            // transactions.
-                            deposit_receipt_version: (is_deposit
-                                && self
-                                    .spec
-                                    .is_canyon_active_at_timestamp(self.evm.block().timestamp))
-                            .then_some(1),
-                        })
-                }
-            },
-        );
-
-        self.evm.db_mut().commit(state);
-
-        Ok(gas_used)
-    }
-
-    fn finish(
-        mut self,
-    ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
-        let requests = if self
-            .spec
-            .is_prague_active_at_timestamp(self.evm.block().timestamp)
-        {
-            // Collect all EIP-6110 deposits
-            let deposit_requests =
-                MyBlockExecutor::<E, R, Spec>::parse_deposits_from_receipts(&self.receipts)?;
-
-            let mut requests = Requests::default();
-
-            if !deposit_requests.is_empty() {
-                requests.push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
-            }
-
-            requests.extend(
-                self.system_caller
-                    .apply_post_execution_changes(&mut self.evm)?,
-            );
-            requests
-        } else {
-            Requests::default()
-        };
-
-        let balance_increments =
-            post_block_balance_increments::<Header>(&self.spec, self.evm.block(), &[], None);
-        // increment balances
-        self.evm
-            .db_mut()
-            .increment_balances(balance_increments.clone())
-            .map_err(|_| BlockValidationError::IncrementBalanceFailed)?;
-        // call state hook with changes due to balance increments.
-        self.system_caller.try_on_state_with(|| {
-            balance_increment_state(&balance_increments, self.evm.db_mut()).map(|state| {
-                (
-                    StateChangeSource::PostBlock(StateChangePostBlockSource::BalanceIncrements),
-                    Cow::Owned(state),
-                )
-            })
-        })?;
-
-        let gas_used = self
-            .receipts
-            .last()
-            .map(|r| r.cumulative_gas_used())
-            .unwrap_or_default();
-        Ok((
-            self.evm,
-            BlockExecutionResult {
-                receipts: self.receipts,
-                requests,
-                gas_used,
-            },
-        ))
-    }
-
-    fn set_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
-        self.system_caller.with_state_hook(hook);
-    }
-
-    fn evm_mut(&mut self) -> &mut Self::Evm {
-        &mut self.evm
-    }
-
-    fn evm(&self) -> &Self::Evm {
-        &self.evm
     }
 }

--- a/crates/sova-evm/src/lib.rs
+++ b/crates/sova-evm/src/lib.rs
@@ -14,7 +14,7 @@ use evm::{SovaEvm, SovaEvmFactory};
 pub use execute::{MyBlockExecutor, SovaBlockExecutorProvider};
 use inspector::SovaInspector;
 pub use inspector::{AccessedStorage, BroadcastResult, SlotProvider, StorageChange, WithInspector};
-pub use precompiles::BitcoinClient;
+pub use precompiles::{BitcoinClient, SovaL1BlockInfo};
 use precompiles::BitcoinRpcPrecompile;
 
 use std::{error::Error, sync::Arc};

--- a/crates/sova-evm/src/lib.rs
+++ b/crates/sova-evm/src/lib.rs
@@ -11,7 +11,7 @@ pub use constants::{
     L1_BLOCK_SATOSHI_SELECTOR,
 };
 use evm::{SovaEvm, SovaEvmFactory};
-pub use execute::{MyBlockExecutor, SovaBlockExecutorProvider};
+pub use execute::SovaBlockExecutorProvider;
 use inspector::SovaInspector;
 pub use inspector::{AccessedStorage, BroadcastResult, SlotProvider, StorageChange, WithInspector};
 use precompiles::BitcoinRpcPrecompile;
@@ -26,7 +26,7 @@ use alloy_evm::{
     block::{BlockExecutorFactory, BlockExecutorFor},
     EvmEnv,
 };
-use alloy_op_evm::OpBlockExecutionCtx;
+use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor};
 use alloy_primitives::{Address, Bytes};
 
 use reth_evm::{ConfigureEvm, InspectorFor};
@@ -198,7 +198,7 @@ impl BlockExecutorFactory for MyEvmConfig {
         I: InspectorFor<Self, &'a mut State<DB>> + 'a,
         <DB as Database>::Error: Send + Sync + 'static,
     {
-        MyBlockExecutor::new(
+        OpBlockExecutor::new(
             evm,
             ctx,
             self.inner.chain_spec().clone(),

--- a/crates/sova-evm/src/lib.rs
+++ b/crates/sova-evm/src/lib.rs
@@ -14,8 +14,8 @@ use evm::{SovaEvm, SovaEvmFactory};
 pub use execute::{MyBlockExecutor, SovaBlockExecutorProvider};
 use inspector::SovaInspector;
 pub use inspector::{AccessedStorage, BroadcastResult, SlotProvider, StorageChange, WithInspector};
-pub use precompiles::{BitcoinClient, SovaL1BlockInfo};
 use precompiles::BitcoinRpcPrecompile;
+pub use precompiles::{BitcoinClient, SovaL1BlockInfo};
 
 use std::{error::Error, sync::Arc};
 

--- a/crates/sova-evm/src/precompiles/btc_client.rs
+++ b/crates/sova-evm/src/precompiles/btc_client.rs
@@ -6,8 +6,8 @@ use bitcoincore_rpc::{bitcoin::Txid, json::DecodeRawTransactionResult, Auth, Cli
 
 use sova_cli::BitcoinConfig;
 
-#[derive(Clone)]
-pub struct L1BlockInfo {
+#[derive(Clone, Default)]
+pub struct SovaL1BlockInfo {
     pub current_block_height: u64,
     pub block_hash_six_blocks_back: B256,
 }
@@ -86,7 +86,7 @@ impl BitcoinClient {
     /// - The blockhash in the block that is considered "confirmed" by the sentinel.
     ///     - For example, if the confirmation threshold on the sentinel is 6,
     ///       the blockhash is queried from 6 blocks behind the current one.
-    pub fn get_current_block_info(&self) -> Result<L1BlockInfo, bitcoincore_rpc::Error> {
+    pub fn get_current_block_info(&self) -> Result<SovaL1BlockInfo, bitcoincore_rpc::Error> {
         // Get the current block height
         let current_block_height = self.client.get_block_count()?;
 
@@ -102,7 +102,7 @@ impl BitcoinClient {
 
         let block_hash_six_blocks_back = B256::new(block_hash_bytes);
 
-        Ok(L1BlockInfo {
+        Ok(SovaL1BlockInfo {
             current_block_height,
             block_hash_six_blocks_back,
         })

--- a/crates/sova-evm/src/precompiles/mod.rs
+++ b/crates/sova-evm/src/precompiles/mod.rs
@@ -3,7 +3,7 @@ mod btc_client;
 mod precompile_utils;
 
 use abi::{abi_encode_tx_data, decode_input, DecodedInput};
-pub use btc_client::BitcoinClient;
+pub use btc_client::{BitcoinClient, SovaL1BlockInfo};
 pub use precompile_utils::BitcoinMethod;
 
 use std::{str::FromStr, sync::Arc};


### PR DESCRIPTION
Follow OP Chain specification for all facets of the NodeBuilder module.

Add RollupArgs to SovaArgs.

Add OpDAConfig.

Use OpBlockExecutor instead of MyBlockExecutor. The evm instance is configured upstream of this module and passed with inspector configured so we can just use OpBlockExecutor.

Remove custom Pool, Network, and Consensus builders. Use Op submodules.

Update SovaPayloadBuilder modules to comply with the Optimism PayloadBuilder module. The sentinel functionality and L1Block functionality was preserved. 

