### PR TITLE
Update indexer endpoint integrations

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -44,8 +44,7 @@ impl Default for BitcoinConfig {
 #[derive(Clone, Debug)]
 pub struct SovaConfig {
     pub bitcoin_config: Arc<BitcoinConfig>,
-    pub network_signing_url: String,
-    pub network_utxo_url: String,
+    pub network_utxos_url: String,
     pub sentinel_url: String,
     pub sentinel_confirmation_threshold: u8,
     pub sequencer_mode: bool,
@@ -54,16 +53,14 @@ pub struct SovaConfig {
 impl SovaConfig {
     pub fn new(
         bitcoin_config: BitcoinConfig,
-        network_signing_url: &str,
-        network_utxo_url: &str,
+        network_utxos_url: &str,
         sentinel_url: &str,
         sentinel_confirmation_threshold: u8,
         sequencer_mode: bool,
     ) -> Self {
         SovaConfig {
             bitcoin_config: Arc::new(bitcoin_config),
-            network_signing_url: network_signing_url.to_owned(),
-            network_utxo_url: network_utxo_url.to_owned(),
+            network_utxos_url: network_utxos_url.to_owned(),
             sentinel_url: sentinel_url.to_owned(),
             sentinel_confirmation_threshold,
             sequencer_mode,
@@ -75,8 +72,7 @@ impl Default for SovaConfig {
     fn default() -> Self {
         SovaConfig {
             bitcoin_config: Arc::new(BitcoinConfig::default()),
-            network_signing_url: String::new(),
-            network_utxo_url: String::new(),
+            network_utxos_url: String::new(),
             sentinel_url: String::new(),
             sentinel_confirmation_threshold: 6,
             sequencer_mode: false,

--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -25,13 +25,9 @@ pub struct SovaArgs {
     #[arg(long, default_value = "password")]
     pub btc_rpc_password: String,
 
-    /// CLI flag to indicate the network signing service url
-    #[arg(long, default_value = "http://127.0.0.1:5555")]
-    pub network_signing_url: String,
-
     /// CLI flag to indicate the network UTXO database url
-    #[arg(long, default_value = "http://127.0.0.1:5557")]
-    pub network_utxo_url: String,
+    #[arg(long, default_value = "http://127.0.0.1:3031")]
+    pub network_utxos_url: String,
 
     /// CLI flag to indicate the storage slot provider url
     #[arg(long, default_value = "http://[::1]:50051")]
@@ -105,8 +101,7 @@ impl Default for SovaArgs {
             network_url: "http://127.0.0.1".to_string(),
             btc_rpc_username: "user".to_string(),
             btc_rpc_password: "password".to_string(),
-            network_signing_url: "http://127.0.0.1:5555".to_string(),
-            network_utxo_url: "http://127.0.0.1:5557".to_string(),
+            network_utxos_url: "http://127.0.0.1:3031".to_string(),
             sentinel_url: "http://[::1]:50051".to_string(),
             sentinel_confirmation_threshold: 6,
             sequencer_mode: false,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -72,8 +72,7 @@ impl SovaNode {
 
         let sova_config = SovaConfig::new(
             btc_config,
-            &args.network_signing_url,
-            &args.network_utxo_url,
+            &args.network_utxos_url,
             &args.sentinel_url,
             args.sentinel_confirmation_threshold,
             args.sequencer_mode,

--- a/crates/sova-evm/src/lib.rs
+++ b/crates/sova-evm/src/lib.rs
@@ -146,8 +146,7 @@ impl MyEvmConfig {
         let bitcoin_precompile = BitcoinRpcPrecompile::new(
             bitcoin_client.clone(),
             config.bitcoin_config.network,
-            config.network_signing_url.clone(),
-            config.network_utxo_url.clone(),
+            config.network_utxos_url.clone(),
             config.sequencer_mode,
         )?;
 

--- a/crates/sova-evm/src/precompiles/btc_client.rs
+++ b/crates/sova-evm/src/precompiles/btc_client.rs
@@ -80,8 +80,8 @@ impl BitcoinClient {
         self.client.send_raw_transaction(tx)
     }
 
-    /// Used by the PayloadBuilder flow to snap show the Bitcoin
-    /// context at the time of block building. This fucntion returns:
+    /// Used by the PayloadBuilder flow to record the Bitcoin context
+    /// at the time of block building. This function returns:
     /// - current BTC block height
     /// - The blockhash in the block that is considered "confirmed" by the sentinel.
     ///     - For example, if the confirmation threshold on the sentinel is 6,


### PR DESCRIPTION
- The execution client no longer calls the network signing service directly. This call is proxied through the indexing layer. This removes a cli arg and resulted in the renaming of a few variables in addition to the logic changes.

- Small typos and docs updates