### PR TITLE
fix: update gas limits and base costs for Bitcoin methods

### DIFF
--- a/crates/sova-evm/src/precompiles/precompile_utils.rs
+++ b/crates/sova-evm/src/precompiles/precompile_utils.rs
@@ -199,18 +199,18 @@ mod tests {
     fn test_gas_calculation() {
         // Test BroadcastTransaction (fixed gas)
         let method = BitcoinMethod::BroadcastTransaction;
-        assert_eq!(method.calculate_gas_used(0), 21_000);
-        assert_eq!(method.calculate_gas_used(1000), 21_000);
+        assert_eq!(method.calculate_gas_used(0), 30_000);
+        assert_eq!(method.calculate_gas_used(1000), 30_000);
 
         // Test DecodeTransaction (variable gas)
         let method = BitcoinMethod::DecodeTransaction;
-        assert_eq!(method.calculate_gas_used(0), 4_000);
-        assert_eq!(method.calculate_gas_used(1000), 4_000 + 3000);
+        assert_eq!(method.calculate_gas_used(0), 3_000);
+        assert_eq!(method.calculate_gas_used(1000), 3_000 + 3_000);
 
         // Test gas limit check
         let method = BitcoinMethod::DecodeTransaction;
-        assert!(!method.is_gas_limit_exceeded(1000)); // 4_000 + 3000 < 150_000
-        assert!(method.is_gas_limit_exceeded(50000)); // 4_000 + 150_000 > 150_000
+        assert!(!method.is_gas_limit_exceeded(1000)); // 3_000 + 3_000 < 150_000
+        assert!(method.is_gas_limit_exceeded(1_000_000)); // 3_000 + 3_000_000 > 3_000_000
     }
 
     #[test]

--- a/crates/sova-evm/src/precompiles/precompile_utils.rs
+++ b/crates/sova-evm/src/precompiles/precompile_utils.rs
@@ -40,13 +40,13 @@ impl BitcoinMethod {
     fn gas_config(&self) -> GasConfig {
         match self {
             Self::BroadcastTransaction => GasConfig {
-                limit: 100_000,
-                base_cost: 21_000,
+                limit: 30_000,
+                base_cost: 30_000,
                 cost_per_byte: 0,
             },
             Self::DecodeTransaction => GasConfig {
-                limit: 150_000,
-                base_cost: 4_000,
+                limit: 3_000_000,
+                base_cost: 3_000,
                 cost_per_byte: 3,
             },
             Self::ConvertAddress => GasConfig {
@@ -55,8 +55,8 @@ impl BitcoinMethod {
                 cost_per_byte: 0,
             },
             Self::VaultSpend => GasConfig {
-                limit: 25_000,
-                base_cost: 25_000,
+                limit: 30_000,
+                base_cost: 30_000,
                 cost_per_byte: 0,
             },
         }


### PR DESCRIPTION
# Reasoning
1. **BroadcastTransaction**
   This will be called by the system after a tx has been decoded (next bullet). Therefore the highest cost centre (decoding) has already been factored in, doesn't make sense to double-charge.
2. **DecodeTransaction**
   This deserializes the tx. We want to accomodate the largest of txs (while most txs are less than 500 bytes, the theoritical max can reach 1_000_000), therefore the user should pay a premium upfront, and pay as they go and it should accommodate the max limit as well. The cost_per_byte cannot be too high that it disincentivizes deposits on sova.
3. **VaultSpend**
   Made the gas cost uniform as `BroadcastTransaction`