### PR TITLE
fix: gas calc math, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make run-sova-regtest
 
 ### For Operators (WIP)
 
-Operators can join the Testnet by staking Testnet Sova and syncing the historical chain data. For more information on how to join the Testnet as an operator view our [Operator Guide]() in the docs. This guide will run you through starting a VM, installing the EigenLayer CLI, registering as an operator, and running the Sova validator.
+Operators are free to join the testnet and sync their own historical chain data from genesis. For more information on how to join the Testnet as an operator view our [Operator Guide](https://docs.sova.io/node-operators/running-sova) in the docs.
 
 ### Devnet
 
@@ -54,9 +54,20 @@ For testing sova-reth in a devnet environment, it is recommended to use [running
 
 ## Precompiles
 
-The Bitcoin precompiles are found at address 0x999 and accept a bytes payload along with a 4 bytes method identifier. The method identifier specifies the bitcoin rpc call that should be called with the payload data.
+The Bitcoin precompiles are found at address 0x999, 0x998, 0x997, 0x996.
 
-For more information on how to use the precompiles see this [section](https://docs.sova.io/developers/bitcoin-precompiles) in the docs.
+ Precompile Name | Address | Description |
+|---|---|---|
+| **Broadcast Transaction** | `0x999` | Broadcasts Bitcoin transactions |
+| **Decode Transaction** | `0x998` | Decodes raw Bitcoin transactions |
+| **Convert Address** | `0x997` | EVM to Bitcoin address conversion |
+| **Vault Spend** | `0x996` | Network vault spending |
+
+For more information on how to use the precompiles see related [docs](https://docs.sova.io/developers/bitcoin-precompiles).
+
+## Sentinel
+
+The sentinel is a custom add-on component to every sove-reth node. It is used by the Sova EVM to enforce Bitcoin finality. Transactions on Sova that have associated Bitcoin transactions are considered final after 6 Bitcoin block confirmations. If a transaction that was flagged by the chain is not confirmed on Bitcoin, the Sova state associated with the flagged Bitcoins tx will be reverted after 21 blocks.
 
 ## License
 

--- a/crates/sova-evm/src/precompiles/mod.rs
+++ b/crates/sova-evm/src/precompiles/mod.rs
@@ -10,7 +10,7 @@ use sova_cli::BitcoinConfig;
 
 use std::{env, str::FromStr, sync::Arc};
 
-use reqwest::blocking::Client as ReqwestClient;
+use reqwest::blocking::Client as BlockingRequestClient;
 use serde::Deserialize;
 
 use alloy_primitives::{Address, Bytes};
@@ -80,7 +80,7 @@ struct UtxoUpdate {
 pub struct BitcoinRpcPrecompile {
     bitcoin_client: Arc<BitcoinClient>,
     network: Network,
-    http_client: Arc<ReqwestClient>,
+    http_client: Arc<BlockingRequestClient>,
     network_utxos_url: String,
     sequencer_mode: bool,
     address_deriver: Arc<SovaAddressDeriver>,
@@ -96,7 +96,7 @@ impl Default for BitcoinRpcPrecompile {
         Self {
             bitcoin_client: Arc::new(BitcoinClient::default()),
             network: Network::Regtest,
-            http_client: Arc::new(ReqwestClient::new()),
+            http_client: Arc::new(BlockingRequestClient::new()),
             network_utxos_url: String::new(),
             sequencer_mode: false,
             address_deriver,
@@ -136,7 +136,7 @@ impl BitcoinRpcPrecompile {
         Ok(Self {
             bitcoin_client,
             network,
-            http_client: Arc::new(ReqwestClient::new()),
+            http_client: Arc::new(BlockingRequestClient::new()),
             network_utxos_url,
             sequencer_mode,
             address_deriver,

--- a/crates/sova-evm/src/precompiles/precompile_utils.rs
+++ b/crates/sova-evm/src/precompiles/precompile_utils.rs
@@ -54,7 +54,7 @@ impl BitcoinMethodHelper {
     pub fn calculate_gas_used(method: &BitcoinPrecompileMethod, input_length: usize) -> u64 {
         let config = Self::gas_config(method);
         let input_len_u64 = input_length as u64;
-        
+
         // Use saturating arithmetic to prevent overflow
         let variable_cost = input_len_u64.saturating_mul(config.cost_per_byte);
         config.base_cost.saturating_add(variable_cost)
@@ -116,26 +116,29 @@ mod tests {
     #[test]
     fn test_overflow_protection() {
         let method = BitcoinPrecompileMethod::DecodeTransaction;
-        
+
         // Test with very large input that would cause overflow
         let large_input = usize::MAX;
         let gas_used = BitcoinMethodHelper::calculate_gas_used(&method, large_input);
-        
+
         // Should return u64::MAX when overflow occurs
         assert_eq!(gas_used, u64::MAX);
-        
+
         // Should be detected as exceeding gas limit
-        assert!(BitcoinMethodHelper::is_gas_limit_exceeded(&method, large_input));
+        assert!(BitcoinMethodHelper::is_gas_limit_exceeded(
+            &method,
+            large_input
+        ));
     }
 
     #[test]
     fn test_saturating_arithmetic() {
         let method = BitcoinPrecompileMethod::DecodeTransaction;
-        
+
         // Test saturating version with large input
         let large_input = usize::MAX;
         let gas_used = BitcoinMethodHelper::calculate_gas_used(&method, large_input);
-        
+
         // Should saturate at u64::MAX
         assert_eq!(gas_used, u64::MAX);
     }
@@ -143,12 +146,13 @@ mod tests {
     #[test]
     fn test_edge_cases() {
         let method = BitcoinPrecompileMethod::DecodeTransaction;
-        
+
         // Test with input that causes multiplication overflow
         let config = BitcoinMethodHelper::gas_config(&method);
         if config.cost_per_byte > 0 {
             let overflow_input = (u64::MAX / config.cost_per_byte) + 1;
-            let gas_used = BitcoinMethodHelper::calculate_gas_used(&method, overflow_input as usize);
+            let gas_used =
+                BitcoinMethodHelper::calculate_gas_used(&method, overflow_input as usize);
             assert_eq!(gas_used, u64::MAX);
         }
     }

--- a/crates/sova-evm/src/precompiles/precompile_utils.rs
+++ b/crates/sova-evm/src/precompiles/precompile_utils.rs
@@ -49,10 +49,15 @@ impl BitcoinMethodHelper {
         Self::gas_config(method).limit
     }
 
-    /// Calculate the gas used for a method, accounting for input size where relevant
+    /// Calculate the gas used for a method using saturating arithmetic
+    /// This version never overflows but may saturate at u64::MAX
     pub fn calculate_gas_used(method: &BitcoinPrecompileMethod, input_length: usize) -> u64 {
         let config = Self::gas_config(method);
-        config.base_cost + (input_length as u64 * config.cost_per_byte)
+        let input_len_u64 = input_length as u64;
+        
+        // Use saturating arithmetic to prevent overflow
+        let variable_cost = input_len_u64.saturating_mul(config.cost_per_byte);
+        config.base_cost.saturating_add(variable_cost)
     }
 
     /// Check if the calculated gas exceeds the method's limit
@@ -102,9 +107,49 @@ mod tests {
 
         // Test gas limit check
         let method = BitcoinPrecompileMethod::DecodeTransaction;
-        assert!(!BitcoinMethodHelper::is_gas_limit_exceeded(&method, 1000)); // 3_000 + 3_000 < 150_000
+        assert!(!BitcoinMethodHelper::is_gas_limit_exceeded(&method, 1000)); // 3_000 + 3_000 < 3_000_000
         assert!(BitcoinMethodHelper::is_gas_limit_exceeded(
             &method, 1_000_000
         )); // 3_000 + 3_000_000 > 3_000_000
+    }
+
+    #[test]
+    fn test_overflow_protection() {
+        let method = BitcoinPrecompileMethod::DecodeTransaction;
+        
+        // Test with very large input that would cause overflow
+        let large_input = usize::MAX;
+        let gas_used = BitcoinMethodHelper::calculate_gas_used(&method, large_input);
+        
+        // Should return u64::MAX when overflow occurs
+        assert_eq!(gas_used, u64::MAX);
+        
+        // Should be detected as exceeding gas limit
+        assert!(BitcoinMethodHelper::is_gas_limit_exceeded(&method, large_input));
+    }
+
+    #[test]
+    fn test_saturating_arithmetic() {
+        let method = BitcoinPrecompileMethod::DecodeTransaction;
+        
+        // Test saturating version with large input
+        let large_input = usize::MAX;
+        let gas_used = BitcoinMethodHelper::calculate_gas_used(&method, large_input);
+        
+        // Should saturate at u64::MAX
+        assert_eq!(gas_used, u64::MAX);
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        let method = BitcoinPrecompileMethod::DecodeTransaction;
+        
+        // Test with input that causes multiplication overflow
+        let config = BitcoinMethodHelper::gas_config(&method);
+        if config.cost_per_byte > 0 {
+            let overflow_input = (u64::MAX / config.cost_per_byte) + 1;
+            let gas_used = BitcoinMethodHelper::calculate_gas_used(&method, overflow_input as usize);
+            assert_eq!(gas_used, u64::MAX);
+        }
     }
 }


### PR DESCRIPTION
- readme updates for sentinel and precompiles
- saturating math in gas calc
- rename var for clarity