### PR TITLE
fix: state root warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9739,7 +9739,7 @@ dependencies = [
 
 [[package]]
 name = "sova"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "clap",
  "eyre",
@@ -9756,7 +9756,7 @@ dependencies = [
 
 [[package]]
 name = "sova-chainspec"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -9772,7 +9772,7 @@ dependencies = [
 
 [[package]]
 name = "sova-evm"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9819,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "sova-node"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9739,7 +9739,7 @@ dependencies = [
 
 [[package]]
 name = "sova"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "eyre",
@@ -9756,7 +9756,7 @@ dependencies = [
 
 [[package]]
 name = "sova-chainspec"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -9772,7 +9772,7 @@ dependencies = [
 
 [[package]]
 name = "sova-evm"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9819,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "sova-node"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/evm/src/executor.rs
+++ b/evm/src/executor.rs
@@ -322,7 +322,7 @@ where
                     changes.insert(*address, revm_acc);
 
                     if !commit {
-                        return Ok(None);
+                        continue;
                     }
 
                     self.system_caller.on_state(

--- a/evm/src/executor.rs
+++ b/evm/src/executor.rs
@@ -244,6 +244,8 @@ where
         // Snapshot pre-execution bundle so we can discard the simulation effects cleanly.
         let pre_execution_bundle = self.evm.db_mut().take_bundle();
 
+        let mut commit: bool = true;
+
         // Run the TX once to populate the inspector's revert cache
         let pending_reverts: Vec<(Address, reth_revm::db::states::TransitionAccount)> = {
             let mut per_tx_insp = MaybeSovaInspector::empty(NoOpInspector);
@@ -264,9 +266,13 @@ where
             );
             evm_sim.enable_inspector();
 
-            evm_sim
+            let exec_result_and_state = evm_sim
                 .transact(&tx)
                 .map_err(|err| BlockExecutionError::evm(err, tx_hash))?;
+
+            if !f(&exec_result_and_state.result).should_commit() {
+                commit = false;
+            }
 
             let (_, insp, _) = evm_sim.components_mut();
             if let Some(sova) = insp.sova_mut() {
@@ -314,6 +320,16 @@ where
                     // Commit the change
                     let mut changes: HashMap<Address, revm::state::Account> = HashMap::new();
                     changes.insert(*address, revm_acc);
+
+                    if !commit {
+                        return Ok(None);
+                    }
+
+                    self.system_caller.on_state(
+                        StateChangeSource::Transaction(self.receipts.len()),
+                        &changes,
+                    );
+
                     self.evm.db_mut().commit(changes);
                 }
             }
@@ -357,7 +373,7 @@ where
             (result, state)
         };
 
-        if !f(&result).should_commit() {
+        if !commit {
             return Ok(None);
         }
 

--- a/evm/src/precompiles/bitcoin_precompile.rs
+++ b/evm/src/precompiles/bitcoin_precompile.rs
@@ -648,11 +648,6 @@ impl BitcoinRpcPrecompile {
             derived_bitcoin_address
         };
 
-        debug!(
-            "Derived Bitcoin address in convert_address precompile: {}",
-            bitcoin_address
-        );
-
         Ok(PrecompileOutput::new(
             gas_used,
             Bytes::from(bitcoin_address.as_bytes().to_vec()),


### PR DESCRIPTION
Fix these warnings:
```
WARN State root task returned incorrect state root
WARN Failed to compute state root in parallel 
```

system_caller.on_state() hook was not being called in the revert flow. In result of this, when any `pending_reverts` were applied to the db, the state root system calls were being missed.

This commit pattern now follows the commit pattern from canonical commits where we check:
1. if we should commit
2. call system_caller.on_state() hook
3. commit to db

----

Additional changes:
- Enforces address derivation invariant. Where enclave and verifier derivations need to be the same when running in sequencer mode. Eventually these should be pulled from shared lib.
- bumped version to 0.3.0